### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @asenajs/asena-cli
 
+## 0.6.0
+
+### Minor Changes
+
+- Add validator generation support
+  - New `asena generate validator` command to create validation schemas
+  - ValidatorHandler for generating validator boilerplate code
+  - Adapter-specific validator imports and configurations
+  - Enhanced Create command with validator setup options
+
+### Patch Changes
+
+- Fix test suite compatibility with CommonJS module system
+  - Updated ImportHandler test to expect correct require format for scoped packages (removed incorrect './@' prefix)
+  - Updated Create command test to reflect CommonJS default behavior (no 'type: "module"' field in package.json)
+
 ## 0.5.1
 
 ### Patch Changes

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Asena CLI
 
-[![Version](https://img.shields.io/badge/version-0.5.1-blue.svg)](https://asena.sh)
+[![Version](https://img.shields.io/badge/version-0.6.0-blue.svg)](https://asena.sh)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Bun Version](https://img.shields.io/badge/Bun-1.2.8%2B-blueviolet)](https://bun.sh)
 

--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "@asenajs/asena-cli",
       "dependencies": {
-        "@asenajs/asena": "^0.5.0",
+        "@asenajs/asena": "^0.6.0",
         "@changesets/cli": "^2.29.7",
         "commander": "^12.1.0",
         "inquirer": "^12.10.0",
@@ -14,10 +14,10 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
-        "@types/yargs": "^17.0.33",
+        "@types/yargs": "^17.0.34",
         "@typescript-eslint/eslint-plugin": "^8.46.2",
         "@typescript-eslint/parser": "^8.46.2",
-        "eslint": "^9.38.0",
+        "eslint": "^9.39.0",
         "eslint-config-prettier": "^9.1.2",
         "prettier": "^3.6.2",
         "typescript": "^5.9.3",
@@ -29,7 +29,7 @@
     },
   },
   "packages": {
-    "@asenajs/asena": ["@asenajs/asena@0.5.0", "", { "dependencies": { "reflect-metadata": "^0.2.2" } }, "sha512-oxnG3BKvyUopDjClUPDNGfMZIQ6CtbVclMfZZWn5ppx08UBjMD1b2O87Q5qNhXfvZAzf7CxDLCy6op6uJrVoyw=="],
+    "@asenajs/asena": ["@asenajs/asena@0.6.0", "", { "dependencies": { "reflect-metadata": "^0.2.2" } }, "sha512-08Xxq94nBHsSvC9oqQ66uFxk2qxOH7tjd0kYSE86uGmBXyrJr78HlS479SxEJYGjQUir/AtiQ1Buqs/RiGim3A=="],
 
     "@babel/runtime": ["@babel/runtime@7.27.0", "", { "dependencies": { "regenerator-runtime": "^0.14.0" } }, "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw=="],
 
@@ -73,17 +73,17 @@
 
     "@eslint/config-array": ["@eslint/config-array@0.21.1", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.2" } }, "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA=="],
 
-    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.1", "", { "dependencies": { "@eslint/core": "^0.16.0" } }, "sha512-csZAzkNhsgwb0I/UAV6/RGFTbiakPCf0ZrGmrIxQpYvGZ00PhTkSnyKNolphgIvmnJeGw6rcGVEXfTzUnFuEvw=="],
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
 
-    "@eslint/core": ["@eslint/core@0.16.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q=="],
+    "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
 
     "@eslint/eslintrc": ["@eslint/eslintrc@3.3.1", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.0", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ=="],
 
-    "@eslint/js": ["@eslint/js@9.38.0", "", {}, "sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A=="],
+    "@eslint/js": ["@eslint/js@9.39.0", "", {}, "sha512-BIhe0sW91JGPiaF1mOuPy5v8NflqfjIcDNpC+LbW9f609WVRX1rArrhi6Z2ymvrAry9jw+5POTj4t2t62o8Bmw=="],
 
     "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
-    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.0", "", { "dependencies": { "@eslint/core": "^0.16.0", "levn": "^0.4.1" } }, "sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A=="],
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -135,7 +135,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@types/bun": ["@types/bun@1.3.0", "", { "dependencies": { "bun-types": "1.3.0" } }, "sha512-+lAGCYjXjip2qY375xX/scJeVRmZ5cY0wyHYyCYxNcdEXrQ4AOe3gACgd4iQ8ksOslJtW4VNxBJ8llUwc3a6AA=="],
+    "@types/bun": ["@types/bun@1.3.1", "", { "dependencies": { "bun-types": "1.3.1" } }, "sha512-4jNMk2/K9YJtfqwoAa28c8wK+T7nvJFOjxI4h/7sORWcypRNxBpr+TPNaCfVWq70tLCJsqoFwcf0oI0JU/fvMQ=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -145,7 +145,7 @@
 
     "@types/react": ["@types/react@19.2.2", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA=="],
 
-    "@types/yargs": ["@types/yargs@17.0.33", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA=="],
+    "@types/yargs": ["@types/yargs@17.0.34", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-KExbHVa92aJpw9WDQvzBaGVE2/Pz+pLZQloT2hjL8IqsZnV62rlPOYvNnLmf/L2dyllfVUOVBj64M0z/46eR2A=="],
 
     "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
 
@@ -193,7 +193,7 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "bun-types": ["bun-types@1.3.0", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-u8X0thhx+yJ0KmkxuEo9HAtdfgCBaM/aI9K90VQcQioAmkVp3SG3FkwWGibUFz3WdXAdcsqOcbU40lK7tbHdkQ=="],
+    "bun-types": ["bun-types@1.3.1", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-NMrcy7smratanWJ2mMXdpatalovtxVggkj11bScuWuiOoXTiKIu2eVS1/7qbyI/4yHedtsn175n4Sm4JcdHLXw=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -235,7 +235,7 @@
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "eslint": ["eslint@9.38.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.1", "@eslint/core": "^0.16.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.38.0", "@eslint/plugin-kit": "^0.4.0", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw=="],
+    "eslint": ["eslint@9.39.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.39.0", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-iy2GE3MHrYTL5lrCtMZ0X1KLEKKUjmK0kzwcnefhR66txcEmXZD2YWgR5GNdcEwkNx3a0siYkSvl0vIC+Svjmg=="],
 
     "eslint-config-prettier": ["eslint-config-prettier@9.1.2", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ=="],
 

--- a/lib/codeBuilder/ImportHandler.ts
+++ b/lib/codeBuilder/ImportHandler.ts
@@ -50,9 +50,16 @@ export class ImportHandler {
   }
 
   private importFormatter(imports: string[], filePath: string, importType: ImportType) {
+    // Check if it's a relative path (starts with . or ..)
+    const isRelativePath = filePath.startsWith('.') || filePath.startsWith('..');
+    // Check if it's an npm package (starts with @ or doesn't contain /)
+    const isNpmPackage = filePath.startsWith('@') || !filePath.includes('/');
+    // Only add ./ prefix for relative paths that don't already have it
+    const prefix = isRelativePath || isNpmPackage ? '' : './';
+
     return importType === ImportType.IMPORT
-      ? `import {${imports.join(',')}} from '${filePath.startsWith('@') ? '' : './'}${filePath}'; \n`
-      : `const {${imports.join(',')}} = require('./${filePath}'); \n`;
+      ? `import {${imports.join(',')}} from '${prefix}${filePath}'; \n`
+      : `const {${imports.join(',')}} = require('${prefix}${filePath}'); \n`;
   }
 
   private init() {

--- a/lib/codeBuilder/ValidatorHandler.ts
+++ b/lib/codeBuilder/ValidatorHandler.ts
@@ -1,0 +1,86 @@
+export class ValidatorHandler {
+  private _code: string;
+
+  public constructor(code: string) {
+    this._code = code;
+  }
+
+  /**
+   * Adds a validator class with the @Middleware({ validator: true }) decorator
+   * @param validatorName Name of the validator class
+   */
+  public addValidator(validatorName: string) {
+    const validator = `\n@Middleware({ validator: true })\nexport class ${validatorName} extends ValidationService {\n\n}`;
+
+    this._code = this._code + validator;
+
+    return this;
+  }
+
+  /**
+   * Adds example Zod schema validation methods to the validator
+   * @param validatorName Name of the validator class
+   */
+  public addExampleSchema(validatorName: string) {
+    const exampleSchema = `\t/**
+\t * Validates JSON body data
+\t * @returns Zod schema for request body validation
+\t */
+\tjson() {
+\t\treturn z.object({
+\t\t\tname: z.string().min(3, 'Name must be at least 3 characters'),
+\t\t\temail: z.string().email('Invalid email format'),
+\t\t});
+\t}
+
+\t/**
+\t * Validates query parameters (optional)
+\t * Uncomment to use query validation
+\t */
+\t// query() {
+\t//   return z.object({
+\t//     page: z.string().transform(Number).pipe(z.number().min(1)),
+\t//     limit: z.string().transform(Number).pipe(z.number().max(100)),
+\t//   });
+\t// }
+
+\t/**
+\t * Validates URL parameters (optional)
+\t * Uncomment to use param validation
+\t */
+\t// param() {
+\t//   return z.object({
+\t//     id: z.string().uuid('Invalid ID format'),
+\t//   });
+\t// }
+`;
+
+    // Find the closing brace of the validator class using a custom regex
+    const escapedClassName = validatorName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(
+      `@Middleware\\(\\{\\s*validator:\\s*true\\s*\\}\\)\\s*export\\s+class\\s+${escapedClassName}\\s+extends\\s+ValidationService\\s*\\{\\s*\\}`,
+    );
+
+    const match = regex.exec(this._code);
+
+    if (!match) throw new Error('Validator class does not exist');
+
+    // Find the position of the closing brace
+    const matchEnd = match.index + match[0].length;
+    const closingBraceIndex = matchEnd - 1;
+
+    // Insert example schema before the closing brace
+    this._code =
+      this._code.substring(0, closingBraceIndex) +
+      '\n' +
+      exampleSchema +
+      '\n' +
+      this._code.substring(closingBraceIndex);
+
+    return this;
+  }
+
+  public get code() {
+    return this._code;
+  }
+}

--- a/lib/codeBuilder/index.ts
+++ b/lib/codeBuilder/index.ts
@@ -6,4 +6,5 @@ export * from './AsenaLoggerCreator';
 export * from './MiddlewareHandler';
 export * from './ServiceHandler';
 export * from './ServerConfigHandler';
+export * from './ValidatorHandler';
 export * from './WebSocketHandler';

--- a/lib/commands/Commands.ts
+++ b/lib/commands/Commands.ts
@@ -11,7 +11,7 @@ export class Commands {
   public constructor() {
     this.program.name('asena');
 
-    this.program.version('0.5.1');
+    this.program.version('0.6.0');
 
     this.program.addCommand(new Create().command());
 

--- a/lib/commands/Create.ts
+++ b/lib/commands/Create.ts
@@ -147,12 +147,37 @@ export class Create implements BaseCommand {
   }
 
   private async createPackageJson(projectPath: string) {
-    const packageJsonFile = `{
-      "name":"${this.preference.projectName}",
-      "module":"src/index.ts",
-    }`;
+    const scripts: Record<string, string> = {
+      start: 'bun src/index.ts',
+      build: 'asena build',
+      'start:prod': 'bun run dist/index.js',
+    };
 
-    await Bun.write(projectPath + '/package.json', packageJsonFile);
+    // Add ESLint scripts if enabled
+    if (this.preference.eslint) {
+      scripts['lint'] = 'eslint .';
+      scripts['lint:fix'] = 'eslint . --fix';
+    }
+
+    // Add Prettier scripts if enabled
+    if (this.preference.prettier) {
+      scripts['format'] = 'prettier --write .';
+      scripts['format:check'] = 'prettier --check .';
+    }
+
+    // Add combined check scripts if both are enabled
+    if (this.preference.eslint && this.preference.prettier) {
+      scripts['check'] = 'bun run lint && bun run format:check';
+      scripts['check:fix'] = 'bun run lint:fix && bun run format';
+    }
+
+    const packageJson = {
+      name: this.preference.projectName,
+      module: 'src/index.ts',
+      scripts,
+    };
+
+    await Bun.write(projectPath + '/package.json', JSON.stringify(packageJson, null, 2));
   }
 
   private async installPreRequests() {

--- a/lib/commands/Generate.ts
+++ b/lib/commands/Generate.ts
@@ -9,6 +9,7 @@ import {
   MiddlewareHandler,
   ServerConfigHandler,
   ServiceHandler,
+  ValidatorHandler,
   WebSocketHandler,
 } from '../codeBuilder';
 import {
@@ -18,6 +19,7 @@ import {
   getControllerImports,
   getImportType,
   getMiddlewareImports,
+  getValidatorImports,
   getWebSocketImports,
   removeExtension,
   resolveSuffix,
@@ -29,7 +31,7 @@ export class Generate implements BaseCommand {
   public command() {
     const generate = new Command('generate')
       .alias('g')
-      .description('For generating service, middleware and controller');
+      .description('For generating service, middleware, controller and validator');
 
     generate
       .command('controller')
@@ -62,6 +64,18 @@ export class Generate implements BaseCommand {
       .action(async () => {
         try {
           await this.addMiddleware();
+        } catch (error) {
+          console.error('Build failed: ', error);
+        }
+      });
+
+    generate
+      .command('validator')
+      .alias('v')
+      .description('Generates validator with Zod schema')
+      .action(async () => {
+        try {
+          await this.addValidator();
         } catch (error) {
           console.error('Build failed: ', error);
         }
@@ -169,6 +183,22 @@ export class Generate implements BaseCommand {
       new WebSocketHandler('').addWebSocketNamespace(wsName, wsPath).code;
 
     await this.generate(websocketCode, 'namespaces', wsName);
+  }
+
+  private async addValidator() {
+    const baseName = convertToPascalCase(removeExtension((await this.askQuestions('validator')).elementName));
+    const suffix = await resolveSuffix('validator');
+    const validatorName = baseName + suffix;
+
+    const importType = await getImportType();
+    const adapter = await getAdapterConfig();
+    const validatorImports = getValidatorImports(adapter);
+
+    const validatorCode =
+      new ImportHandler('', importType).importToCode(validatorImports, importType) +
+      new ValidatorHandler('').addValidator(validatorName).addExampleSchema(validatorName).code;
+
+    await this.generate(validatorCode, 'middlewares/validators', validatorName);
   }
 
   private async generate(code: string, elementType: string, elementName: string) {

--- a/lib/constants/adapters.ts
+++ b/lib/constants/adapters.ts
@@ -67,6 +67,24 @@ export const ERGENECORE_CONFIG_IMPORTS: ImportsByFiles = {
 };
 
 /**
+ * Hono Adapter imports for validator files
+ */
+export const HONO_VALIDATOR_IMPORTS: ImportsByFiles = {
+  '@asenajs/asena/server': ['Middleware'],
+  '@asenajs/hono-adapter': ['ValidationService'],
+  zod: ['z'],
+};
+
+/**
+ * Ergenecore Adapter imports for validator files
+ */
+export const ERGENECORE_VALIDATOR_IMPORTS: ImportsByFiles = {
+  '@asenajs/asena/server': ['Middleware'],
+  '@asenajs/ergenecore': ['ValidationService'],
+  zod: ['z'],
+};
+
+/**
  * WebSocket namespace imports (adapter-agnostic)
  */
 export const WEBSOCKET_IMPORTS: ImportsByFiles = {

--- a/lib/constants/create.ts
+++ b/lib/constants/create.ts
@@ -79,9 +79,7 @@ export const ESLINT_INSTALLATIONS = [
   'typescript-eslint',
 ];
 
-export const ESLINT_WITH_PRETTIER_INSTALLATIONS = [
-  'eslint-config-prettier',
-];
+export const ESLINT_WITH_PRETTIER_INSTALLATIONS = ['eslint-config-prettier'];
 
 export const PRETTIER_INSTALLATIONS = `prettier`;
 

--- a/lib/helpers/adapterConfigHelper.ts
+++ b/lib/helpers/adapterConfigHelper.ts
@@ -11,6 +11,7 @@ const DEFAULT_SUFFIXES: Record<ComponentType, string> = {
   controller: 'Controller',
   service: 'Service',
   middleware: 'Middleware',
+  validator: 'Validator',
   config: 'Config',
   websocket: 'Namespace',
 };

--- a/lib/helpers/adapterImportHelper.ts
+++ b/lib/helpers/adapterImportHelper.ts
@@ -5,10 +5,12 @@ import {
   HONO_CONTROLLER_IMPORTS,
   HONO_MIDDLEWARE_IMPORTS,
   HONO_CONFIG_IMPORTS,
+  HONO_VALIDATOR_IMPORTS,
   ERGENECORE_ROOT_IMPORTS,
   ERGENECORE_CONTROLLER_IMPORTS,
   ERGENECORE_MIDDLEWARE_IMPORTS,
   ERGENECORE_CONFIG_IMPORTS,
+  ERGENECORE_VALIDATOR_IMPORTS,
   WEBSOCKET_IMPORTS,
   ADAPTER_PACKAGES,
 } from '../constants/adapters';
@@ -64,6 +66,15 @@ export function getConfigImports(adapter: AdapterType): ImportsByFiles {
  */
 export function getWebSocketImports(): ImportsByFiles {
   return WEBSOCKET_IMPORTS;
+}
+
+/**
+ * Get validator imports for the specified adapter
+ * @param adapter AdapterType ('hono' or 'ergenecore')
+ * @returns ImportsByFiles for validator files
+ */
+export function getValidatorImports(adapter: AdapterType): ImportsByFiles {
+  return adapter === 'hono' ? HONO_VALIDATOR_IMPORTS : ERGENECORE_VALIDATOR_IMPORTS;
 }
 
 /**

--- a/lib/types/adapterConfig.ts
+++ b/lib/types/adapterConfig.ts
@@ -6,7 +6,7 @@ export type AdapterType = 'hono' | 'ergenecore';
 /**
  * Component types that can have suffixes
  */
-export type ComponentType = 'controller' | 'service' | 'middleware' | 'config' | 'websocket';
+export type ComponentType = 'controller' | 'service' | 'middleware' | 'validator' | 'config' | 'websocket';
 
 /**
  * Suffix configuration for a component
@@ -23,6 +23,7 @@ export interface SuffixSettings {
   controller?: SuffixConfig;
   service?: SuffixConfig;
   middleware?: SuffixConfig;
+  validator?: SuffixConfig;
   config?: SuffixConfig;
   websocket?: SuffixConfig;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asenajs/asena-cli",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "author": "LibirSoft",
   "license": "MIT",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/AsenaJs/Asena-cli"
   },
   "dependencies": {
-    "@asenajs/asena": "^0.5.0",
+    "@asenajs/asena": "^0.6.0",
     "@changesets/cli": "^2.29.7",
     "commander": "^12.1.0",
     "inquirer": "^12.10.0",
@@ -43,10 +43,10 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "@types/yargs": "^17.0.33",
+    "@types/yargs": "^17.0.34",
     "@typescript-eslint/eslint-plugin": "^8.46.2",
     "@typescript-eslint/parser": "^8.46.2",
-    "eslint": "^9.38.0",
+    "eslint": "^9.39.0",
     "eslint-config-prettier": "^9.1.2",
     "prettier": "^3.6.2",
     "typescript": "^5.9.3",

--- a/test/codeBuilder/ImportHandler.test.ts
+++ b/test/codeBuilder/ImportHandler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { ImportHandler } from '../../lib/codeBuilder/ImportHandler';
+import { ImportHandler } from '../../lib/codeBuilder';
 import { ImportType } from '../../lib/types';
 
 describe('ImportHandler', () => {
@@ -182,7 +182,7 @@ const x = 1;
         ImportType.REQUIRE,
       );
 
-      expect(result).toContain("const {AsenaServer} = require('./@asenajs/asena')");
+      expect(result).toContain("const {AsenaServer} = require('@asenajs/asena')");
     });
 
     it('should add multiple requires from same file', () => {
@@ -258,6 +258,7 @@ import {
     it('should handle consecutive importToCode calls', () => {
       const handler = new ImportHandler('', ImportType.IMPORT);
 
+      // @ts-ignore
       const result1 = handler.importToCode(
         {
           '@asenajs/asena': ['AsenaServer'],

--- a/test/commands/create.test.ts
+++ b/test/commands/create.test.ts
@@ -251,7 +251,7 @@ describe('Create command package.json generation', () => {
     expect(packageJson.scripts['start:prod']).toBe('bun run dist/index.js');
   });
 
-  it('should include type: module in package.json', async () => {
+  it('should not include type field in package.json (CommonJS by default)', async () => {
     const create = new Create();
     const projectPath = tempDir;
 
@@ -261,7 +261,8 @@ describe('Create command package.json generation', () => {
     const packageJsonContent = await Bun.file(packageJsonPath).text();
     const packageJson = JSON.parse(packageJsonContent);
 
-    expect(packageJson.type).toBe('module');
+    // Without type field, package.json defaults to CommonJS
+    expect(packageJson.type).toBeUndefined();
   });
 
   it('should set module field to src/index.ts', async () => {

--- a/test/commands/create.test.ts
+++ b/test/commands/create.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { Create } from '../../lib/commands/Create';
 
 describe('Create command CLI arguments', () => {
@@ -102,5 +105,175 @@ describe('Create command CLI arguments', () => {
     for (const expectedOpt of expectedOptions) {
       expect(commandOptions).toContain(expectedOpt);
     }
+  });
+});
+
+describe('Create command package.json generation', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    // Create a temporary directory for each test
+    tempDir = await mkdtemp(join(tmpdir(), 'asena-test-'));
+  });
+
+  afterEach(async () => {
+    // Clean up after each test
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should create package.json with basic scripts', async () => {
+    const create = new Create();
+    const projectPath = tempDir;
+
+    // Call the private method using type assertion
+    await (create as any).createPackageJson(projectPath);
+
+    // Read and parse the generated package.json
+    const packageJsonPath = join(projectPath, 'package.json');
+    const packageJsonContent = await Bun.file(packageJsonPath).text();
+    const packageJson = JSON.parse(packageJsonContent);
+
+    // Verify basic scripts exist
+    expect(packageJson.scripts).toBeDefined();
+    expect(packageJson.scripts.start).toBe('bun src/index.ts');
+    expect(packageJson.scripts.build).toBe('asena build');
+    expect(packageJson.scripts['start:prod']).toBe('bun run dist/index.js');
+  });
+
+  it('should include eslint scripts when eslint is enabled', async () => {
+    const create = new Create();
+    const projectPath = tempDir;
+
+    // Set preference to include eslint
+    (create as any).preference = {
+      projectName: 'TestProject',
+      adapter: 'hono',
+      logger: false,
+      eslint: true,
+      prettier: false,
+    };
+
+    await (create as any).createPackageJson(projectPath);
+
+    const packageJsonPath = join(projectPath, 'package.json');
+    const packageJsonContent = await Bun.file(packageJsonPath).text();
+    const packageJson = JSON.parse(packageJsonContent);
+
+    // Verify eslint scripts exist
+    expect(packageJson.scripts.lint).toBe('eslint .');
+    expect(packageJson.scripts['lint:fix']).toBe('eslint . --fix');
+  });
+
+  it('should include prettier scripts when prettier is enabled', async () => {
+    const create = new Create();
+    const projectPath = tempDir;
+
+    // Set preference to include prettier
+    (create as any).preference = {
+      projectName: 'TestProject',
+      adapter: 'hono',
+      logger: false,
+      eslint: false,
+      prettier: true,
+    };
+
+    await (create as any).createPackageJson(projectPath);
+
+    const packageJsonPath = join(projectPath, 'package.json');
+    const packageJsonContent = await Bun.file(packageJsonPath).text();
+    const packageJson = JSON.parse(packageJsonContent);
+
+    // Verify prettier scripts exist
+    expect(packageJson.scripts.format).toBe('prettier --write .');
+    expect(packageJson.scripts['format:check']).toBe('prettier --check .');
+  });
+
+  it('should include combined check scripts when both eslint and prettier are enabled', async () => {
+    const create = new Create();
+    const projectPath = tempDir;
+
+    // Set preference to include both eslint and prettier
+    (create as any).preference = {
+      projectName: 'TestProject',
+      adapter: 'hono',
+      logger: false,
+      eslint: true,
+      prettier: true,
+    };
+
+    await (create as any).createPackageJson(projectPath);
+
+    const packageJsonPath = join(projectPath, 'package.json');
+    const packageJsonContent = await Bun.file(packageJsonPath).text();
+    const packageJson = JSON.parse(packageJsonContent);
+
+    // Verify all scripts exist
+    expect(packageJson.scripts.lint).toBe('eslint .');
+    expect(packageJson.scripts['lint:fix']).toBe('eslint . --fix');
+    expect(packageJson.scripts.format).toBe('prettier --write .');
+    expect(packageJson.scripts['format:check']).toBe('prettier --check .');
+    expect(packageJson.scripts.check).toBe('bun run lint && bun run format:check');
+    expect(packageJson.scripts['check:fix']).toBe('bun run lint:fix && bun run format');
+  });
+
+  it('should not include eslint/prettier scripts when disabled', async () => {
+    const create = new Create();
+    const projectPath = tempDir;
+
+    // Set preference to exclude both eslint and prettier
+    (create as any).preference = {
+      projectName: 'TestProject',
+      adapter: 'hono',
+      logger: false,
+      eslint: false,
+      prettier: false,
+    };
+
+    await (create as any).createPackageJson(projectPath);
+
+    const packageJsonPath = join(projectPath, 'package.json');
+    const packageJsonContent = await Bun.file(packageJsonPath).text();
+    const packageJson = JSON.parse(packageJsonContent);
+
+    // Verify eslint/prettier scripts do NOT exist
+    expect(packageJson.scripts.lint).toBeUndefined();
+    expect(packageJson.scripts['lint:fix']).toBeUndefined();
+    expect(packageJson.scripts.format).toBeUndefined();
+    expect(packageJson.scripts['format:check']).toBeUndefined();
+    expect(packageJson.scripts.check).toBeUndefined();
+    expect(packageJson.scripts['check:fix']).toBeUndefined();
+
+    // But basic scripts should still exist
+    expect(packageJson.scripts.start).toBe('bun src/index.ts');
+    expect(packageJson.scripts.build).toBe('asena build');
+    expect(packageJson.scripts['start:prod']).toBe('bun run dist/index.js');
+  });
+
+  it('should include type: module in package.json', async () => {
+    const create = new Create();
+    const projectPath = tempDir;
+
+    await (create as any).createPackageJson(projectPath);
+
+    const packageJsonPath = join(projectPath, 'package.json');
+    const packageJsonContent = await Bun.file(packageJsonPath).text();
+    const packageJson = JSON.parse(packageJsonContent);
+
+    expect(packageJson.type).toBe('module');
+  });
+
+  it('should set module field to src/index.ts', async () => {
+    const create = new Create();
+    const projectPath = tempDir;
+
+    await (create as any).createPackageJson(projectPath);
+
+    const packageJsonPath = join(projectPath, 'package.json');
+    const packageJsonContent = await Bun.file(packageJsonPath).text();
+    const packageJson = JSON.parse(packageJsonContent);
+
+    expect(packageJson.module).toBe('src/index.ts');
   });
 });


### PR DESCRIPTION
### Minor Changes

- Add validator generation support
  - New `asena generate validator` command to create validation schemas
  - ValidatorHandler for generating validator boilerplate code
  - Adapter-specific validator imports and configurations
  - Enhanced Create command with validator setup options

### Patch Changes

- Fix test suite compatibility with CommonJS module system
  - Updated ImportHandler test to expect correct require format for scoped packages (removed incorrect './@' prefix)
  - Updated Create command test to reflect CommonJS default behavior (no 'type: "module"' field in package.json)