### PR TITLE
Release: 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # @asenajs/asena-cli
 
+## 0.7.0
+
+### Minor Changes
+
+- ### Import Path Migration
+  - Migrate all generated import paths from `@asenajs/asena/server` and `@asenajs/asena/web` to the new `@asenajs/asena/decorators` and `@asenajs/asena/decorators/http` subpath exports
+  - Service generate command now uses `@asenajs/asena/decorators` instead of `@asenajs/asena/server`
+
+  ### Code Generation Quality
+  - Replace tab indentation with 2-space indentation in all code generators (Controller, Middleware, Validator, WebSocket, ServerConfig)
+  - Use single quotes consistently in generated code
+  - Add proper spacing in class declarations and method signatures
+  - Fix extra whitespace before `export class` in ControllerHandler
+
+  ### Create Command Enhancements
+  - Add `--skip-install` flag for monorepo/offline workflows — writes dependencies to package.json without running `bun install`
+  - Add `.gitignore` generation with sensible defaults (node_modules, dist, .env, IDE files)
+  - Use current folder name as project name when creating in current directory (instead of hardcoded "myApp")
+  - Add `dev` and `dev:hot` scripts to generated package.json
+
+  ### Config Schema & IDE Support
+  - Add JSON Schema for `.asena/config.json` — enables autocomplete and validation in IDEs
+  - Write `config.schema.json` alongside config file with `$schema` reference
+  - Add `$schema` field to AdapterConfig type
+
+  ### Test Fixture Fix
+  - Update fixture `@asenajs/asena` dependency from `^0.4.0` to `^0.7.0`
+  - Install fixture dependencies so integration tests pass
+
+  ### New Tests
+  - ControllerHandler: indentation, spacing, path handling
+  - MiddlewareHandler: structure, indentation, spacing
+  - ValidatorHandler: structure, schema generation
+
+  ### Dependency Updates
+  - `@asenajs/asena` `^0.6.0` → `^0.7.0`
+  - `eslint` `^9.39.0` → `^9.39.4`
+  - `prettier` `^3.6.2` → `^3.8.1`
+  - `typescript-eslint` `^8.46.2` → `^8.58.0`
+  - `inquirer` `^12.10.0` → `^12.11.1`
+
 ## 0.6.0
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 # Asena CLI
 
-[![Version](https://img.shields.io/badge/version-0.6.0-blue.svg)](https://asena.sh)
+[![Version](https://img.shields.io/badge/version-0.7.0-blue.svg)](https://asena.sh)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
-[![Bun Version](https://img.shields.io/badge/Bun-1.2.8%2B-blueviolet)](https://bun.sh)
+[![Bun Version](https://img.shields.io/badge/Bun-1.3.11%2B-blueviolet)](https://bun.sh)
 
 Asena-cli provides several command-line utilities to help developers manage their asena applications efficiently. Here's a comprehensive guide to all available commands.
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,27 +1,28 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "@asenajs/asena-cli",
       "dependencies": {
-        "@asenajs/asena": "^0.6.0",
-        "@changesets/cli": "^2.29.7",
+        "@asenajs/asena": "^0.7.0",
+        "@changesets/cli": "^2.30.0",
         "commander": "^12.1.0",
-        "inquirer": "^12.10.0",
+        "inquirer": "^12.11.1",
         "ora": "^8.2.0",
         "reflect-metadata": "^0.2.2",
         "strip-json-comments": "^5.0.3",
       },
       "devDependencies": {
         "@types/bun": "latest",
-        "@types/yargs": "^17.0.34",
-        "@typescript-eslint/eslint-plugin": "^8.46.2",
-        "@typescript-eslint/parser": "^8.46.2",
-        "eslint": "^9.39.0",
+        "@types/yargs": "^17.0.35",
+        "@typescript-eslint/eslint-plugin": "^8.58.0",
+        "@typescript-eslint/parser": "^8.58.0",
+        "eslint": "^9.39.4",
         "eslint-config-prettier": "^9.1.2",
-        "prettier": "^3.6.2",
+        "prettier": "^3.8.1",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.46.2",
+        "typescript-eslint": "^8.58.0",
       },
       "peerDependencies": {
         "typescript": "^5.0.0",
@@ -29,25 +30,25 @@
     },
   },
   "packages": {
-    "@asenajs/asena": ["@asenajs/asena@0.6.0", "", { "dependencies": { "reflect-metadata": "^0.2.2" } }, "sha512-08Xxq94nBHsSvC9oqQ66uFxk2qxOH7tjd0kYSE86uGmBXyrJr78HlS479SxEJYGjQUir/AtiQ1Buqs/RiGim3A=="],
+    "@asenajs/asena": ["@asenajs/asena@0.7.0", "", { "dependencies": { "reflect-metadata": "^0.2.2" } }, "sha512-qU+NkkorV8rx++AT1snv5WG7+BVaiwzM8541pbENRwYx1nxqp8BgYEv01LHkJFNR28VrEqAo1lhvOuEhNe4oYQ=="],
 
-    "@babel/runtime": ["@babel/runtime@7.27.0", "", { "dependencies": { "regenerator-runtime": "^0.14.0" } }, "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw=="],
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
-    "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.0.13", "", { "dependencies": { "@changesets/config": "^3.1.1", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-BIW7bofD2yAWoE8H4V40FikC+1nNFEKBisMECccS16W1rt6qqhNTBDmIw5HaqmMgtLNz9e7oiALiEUuKrQ4oHg=="],
+    "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.1.0", "", { "dependencies": { "@changesets/config": "^3.1.3", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ=="],
 
     "@changesets/assemble-release-plan": ["@changesets/assemble-release-plan@6.0.9", "", { "dependencies": { "@changesets/errors": "^0.2.0", "@changesets/get-dependents-graph": "^2.1.3", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "semver": "^7.5.3" } }, "sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ=="],
 
     "@changesets/changelog-git": ["@changesets/changelog-git@0.2.1", "", { "dependencies": { "@changesets/types": "^6.1.0" } }, "sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q=="],
 
-    "@changesets/cli": ["@changesets/cli@2.29.7", "", { "dependencies": { "@changesets/apply-release-plan": "^7.0.13", "@changesets/assemble-release-plan": "^6.0.9", "@changesets/changelog-git": "^0.2.1", "@changesets/config": "^3.1.1", "@changesets/errors": "^0.2.0", "@changesets/get-dependents-graph": "^2.1.3", "@changesets/get-release-plan": "^4.0.13", "@changesets/git": "^3.0.4", "@changesets/logger": "^0.1.1", "@changesets/pre": "^2.0.2", "@changesets/read": "^0.6.5", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@changesets/write": "^0.4.0", "@inquirer/external-editor": "^1.0.0", "@manypkg/get-packages": "^1.1.3", "ansi-colors": "^4.1.3", "ci-info": "^3.7.0", "enquirer": "^2.4.1", "fs-extra": "^7.0.1", "mri": "^1.2.0", "p-limit": "^2.2.0", "package-manager-detector": "^0.2.0", "picocolors": "^1.1.0", "resolve-from": "^5.0.0", "semver": "^7.5.3", "spawndamnit": "^3.0.1", "term-size": "^2.1.0" }, "bin": { "changeset": "bin.js" } }, "sha512-R7RqWoaksyyKXbKXBTbT4REdy22yH81mcFK6sWtqSanxUCbUi9Uf+6aqxZtDQouIqPdem2W56CdxXgsxdq7FLQ=="],
+    "@changesets/cli": ["@changesets/cli@2.30.0", "", { "dependencies": { "@changesets/apply-release-plan": "^7.1.0", "@changesets/assemble-release-plan": "^6.0.9", "@changesets/changelog-git": "^0.2.1", "@changesets/config": "^3.1.3", "@changesets/errors": "^0.2.0", "@changesets/get-dependents-graph": "^2.1.3", "@changesets/get-release-plan": "^4.0.15", "@changesets/git": "^3.0.4", "@changesets/logger": "^0.1.1", "@changesets/pre": "^2.0.2", "@changesets/read": "^0.6.7", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@changesets/write": "^0.4.0", "@inquirer/external-editor": "^1.0.2", "@manypkg/get-packages": "^1.1.3", "ansi-colors": "^4.1.3", "enquirer": "^2.4.1", "fs-extra": "^7.0.1", "mri": "^1.2.0", "package-manager-detector": "^0.2.0", "picocolors": "^1.1.0", "resolve-from": "^5.0.0", "semver": "^7.5.3", "spawndamnit": "^3.0.1", "term-size": "^2.1.0" }, "bin": { "changeset": "bin.js" } }, "sha512-5D3Nk2JPqMI1wK25pEymeWRSlSMdo5QOGlyfrKg0AOufrUcjEE3RQgaCpHoBiM31CSNrtSgdJ0U6zL1rLDDfBA=="],
 
-    "@changesets/config": ["@changesets/config@3.1.1", "", { "dependencies": { "@changesets/errors": "^0.2.0", "@changesets/get-dependents-graph": "^2.1.3", "@changesets/logger": "^0.1.1", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "fs-extra": "^7.0.1", "micromatch": "^4.0.8" } }, "sha512-bd+3Ap2TKXxljCggI0mKPfzCQKeV/TU4yO2h2C6vAihIo8tzseAn2e7klSuiyYYXvgu53zMN1OeYMIQkaQoWnA=="],
+    "@changesets/config": ["@changesets/config@3.1.3", "", { "dependencies": { "@changesets/errors": "^0.2.0", "@changesets/get-dependents-graph": "^2.1.3", "@changesets/logger": "^0.1.1", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "fs-extra": "^7.0.1", "micromatch": "^4.0.8" } }, "sha512-vnXjcey8YgBn2L1OPWd3ORs0bGC4LoYcK/ubpgvzNVr53JXV5GiTVj7fWdMRsoKUH7hhhMAQnsJUqLr21EncNw=="],
 
     "@changesets/errors": ["@changesets/errors@0.2.0", "", { "dependencies": { "extendable-error": "^0.1.5" } }, "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow=="],
 
     "@changesets/get-dependents-graph": ["@changesets/get-dependents-graph@2.1.3", "", { "dependencies": { "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "picocolors": "^1.1.0", "semver": "^7.5.3" } }, "sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ=="],
 
-    "@changesets/get-release-plan": ["@changesets/get-release-plan@4.0.13", "", { "dependencies": { "@changesets/assemble-release-plan": "^6.0.9", "@changesets/config": "^3.1.1", "@changesets/pre": "^2.0.2", "@changesets/read": "^0.6.5", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3" } }, "sha512-DWG1pus72FcNeXkM12tx+xtExyH/c9I1z+2aXlObH3i9YA7+WZEVaiHzHl03thpvAgWTRaH64MpfHxozfF7Dvg=="],
+    "@changesets/get-release-plan": ["@changesets/get-release-plan@4.0.15", "", { "dependencies": { "@changesets/assemble-release-plan": "^6.0.9", "@changesets/config": "^3.1.3", "@changesets/pre": "^2.0.2", "@changesets/read": "^0.6.7", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3" } }, "sha512-Q04ZaRPuEVZtA+auOYgFaVQQSA98dXiVe/yFaZfY7hoSmQICHGvP0TF4u3EDNHWmmCS4ekA/XSpKlSM2PyTS2g=="],
 
     "@changesets/get-version-range-type": ["@changesets/get-version-range-type@0.4.0", "", {}, "sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ=="],
 
@@ -55,11 +56,11 @@
 
     "@changesets/logger": ["@changesets/logger@0.1.1", "", { "dependencies": { "picocolors": "^1.1.0" } }, "sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg=="],
 
-    "@changesets/parse": ["@changesets/parse@0.4.1", "", { "dependencies": { "@changesets/types": "^6.1.0", "js-yaml": "^3.13.1" } }, "sha512-iwksMs5Bf/wUItfcg+OXrEpravm5rEd9Bf4oyIPL4kVTmJQ7PNDSd6MDYkpSJR1pn7tz/k8Zf2DhTCqX08Ou+Q=="],
+    "@changesets/parse": ["@changesets/parse@0.4.3", "", { "dependencies": { "@changesets/types": "^6.1.0", "js-yaml": "^4.1.1" } }, "sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A=="],
 
     "@changesets/pre": ["@changesets/pre@2.0.2", "", { "dependencies": { "@changesets/errors": "^0.2.0", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "fs-extra": "^7.0.1" } }, "sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug=="],
 
-    "@changesets/read": ["@changesets/read@0.6.5", "", { "dependencies": { "@changesets/git": "^3.0.4", "@changesets/logger": "^0.1.1", "@changesets/parse": "^0.4.1", "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "p-filter": "^2.1.0", "picocolors": "^1.1.0" } }, "sha512-UPzNGhsSjHD3Veb0xO/MwvasGe8eMyNrR/sT9gR8Q3DhOQZirgKhhXv/8hVsI0QpPjR004Z9iFxoJU6in3uGMg=="],
+    "@changesets/read": ["@changesets/read@0.6.7", "", { "dependencies": { "@changesets/git": "^3.0.4", "@changesets/logger": "^0.1.1", "@changesets/parse": "^0.4.3", "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "p-filter": "^2.1.0", "picocolors": "^1.1.0" } }, "sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA=="],
 
     "@changesets/should-skip-package": ["@changesets/should-skip-package@0.1.2", "", { "dependencies": { "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3" } }, "sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw=="],
 
@@ -67,19 +68,19 @@
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
 
-    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g=="],
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 
-    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.1", "", {}, "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ=="],
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
 
-    "@eslint/config-array": ["@eslint/config-array@0.21.1", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.2" } }, "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA=="],
+    "@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
 
     "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
 
     "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
 
-    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.1", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.0", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ=="],
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.5", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg=="],
 
-    "@eslint/js": ["@eslint/js@9.39.0", "", {}, "sha512-BIhe0sW91JGPiaF1mOuPy5v8NflqfjIcDNpC+LbW9f609WVRX1rArrhi6Z2ymvrAry9jw+5POTj4t2t62o8Bmw=="],
+    "@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
 
     "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
@@ -93,37 +94,37 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
-    "@inquirer/ansi": ["@inquirer/ansi@1.0.1", "", {}, "sha512-yqq0aJW/5XPhi5xOAL1xRCpe1eh8UFVgYFpFsjEqmIR8rKLyP+HINvFXwUaxYICflJrVlxnp7lLN6As735kVpw=="],
+    "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 
-    "@inquirer/checkbox": ["@inquirer/checkbox@4.3.0", "", { "dependencies": { "@inquirer/ansi": "^1.0.1", "@inquirer/core": "^10.3.0", "@inquirer/figures": "^1.0.14", "@inquirer/type": "^3.0.9", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-5+Q3PKH35YsnoPTh75LucALdAxom6xh5D1oeY561x4cqBuH24ZFVyFREPe14xgnrtmGu3EEt1dIi60wRVSnGCw=="],
+    "@inquirer/checkbox": ["@inquirer/checkbox@4.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/core": "^10.3.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA=="],
 
-    "@inquirer/confirm": ["@inquirer/confirm@5.1.19", "", { "dependencies": { "@inquirer/core": "^10.3.0", "@inquirer/type": "^3.0.9" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-wQNz9cfcxrtEnUyG5PndC8g3gZ7lGDBzmWiXZkX8ot3vfZ+/BLjR8EvyGX4YzQLeVqtAlY/YScZpW7CW8qMoDQ=="],
+    "@inquirer/confirm": ["@inquirer/confirm@5.1.21", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ=="],
 
-    "@inquirer/core": ["@inquirer/core@10.3.0", "", { "dependencies": { "@inquirer/ansi": "^1.0.1", "@inquirer/figures": "^1.0.14", "@inquirer/type": "^3.0.9", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-Uv2aPPPSK5jeCplQmQ9xadnFx2Zhj9b5Dj7bU6ZeCdDNNY11nhYy4btcSdtDguHqCT2h5oNeQTcUNSGGLA7NTA=="],
+    "@inquirer/core": ["@inquirer/core@10.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A=="],
 
-    "@inquirer/editor": ["@inquirer/editor@4.2.21", "", { "dependencies": { "@inquirer/core": "^10.3.0", "@inquirer/external-editor": "^1.0.2", "@inquirer/type": "^3.0.9" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-MjtjOGjr0Kh4BciaFShYpZ1s9400idOdvQ5D7u7lE6VztPFoyLcVNE5dXBmEEIQq5zi4B9h2kU+q7AVBxJMAkQ=="],
+    "@inquirer/editor": ["@inquirer/editor@4.2.23", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/external-editor": "^1.0.3", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ=="],
 
-    "@inquirer/expand": ["@inquirer/expand@4.0.21", "", { "dependencies": { "@inquirer/core": "^10.3.0", "@inquirer/type": "^3.0.9", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-+mScLhIcbPFmuvU3tAGBed78XvYHSvCl6dBiYMlzCLhpr0bzGzd8tfivMMeqND6XZiaZ1tgusbUHJEfc6YzOdA=="],
+    "@inquirer/expand": ["@inquirer/expand@4.0.23", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/type": "^3.0.10", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew=="],
 
-    "@inquirer/external-editor": ["@inquirer/external-editor@1.0.2", "", { "dependencies": { "chardet": "^2.1.0", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ=="],
+    "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 
-    "@inquirer/figures": ["@inquirer/figures@1.0.14", "", {}, "sha512-DbFgdt+9/OZYFM+19dbpXOSeAstPy884FPy1KjDu4anWwymZeOYhMY1mdFri172htv6mvc/uvIAAi7b7tvjJBQ=="],
+    "@inquirer/figures": ["@inquirer/figures@1.0.15", "", {}, "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g=="],
 
-    "@inquirer/input": ["@inquirer/input@4.2.5", "", { "dependencies": { "@inquirer/core": "^10.3.0", "@inquirer/type": "^3.0.9" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-7GoWev7P6s7t0oJbenH0eQ0ThNdDJbEAEtVt9vsrYZ9FulIokvd823yLyhQlWHJPGce1wzP53ttfdCZmonMHyA=="],
+    "@inquirer/input": ["@inquirer/input@4.3.1", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g=="],
 
-    "@inquirer/number": ["@inquirer/number@3.0.21", "", { "dependencies": { "@inquirer/core": "^10.3.0", "@inquirer/type": "^3.0.9" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-5QWs0KGaNMlhbdhOSCFfKsW+/dcAVC2g4wT/z2MCiZM47uLgatC5N20kpkDQf7dHx+XFct/MJvvNGy6aYJn4Pw=="],
+    "@inquirer/number": ["@inquirer/number@3.0.23", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg=="],
 
-    "@inquirer/password": ["@inquirer/password@4.0.21", "", { "dependencies": { "@inquirer/ansi": "^1.0.1", "@inquirer/core": "^10.3.0", "@inquirer/type": "^3.0.9" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-xxeW1V5SbNFNig2pLfetsDb0svWlKuhmr7MPJZMYuDnCTkpVBI+X/doudg4pznc1/U+yYmWFFOi4hNvGgUo7EA=="],
+    "@inquirer/password": ["@inquirer/password@4.0.23", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/core": "^10.3.2", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA=="],
 
-    "@inquirer/prompts": ["@inquirer/prompts@7.9.0", "", { "dependencies": { "@inquirer/checkbox": "^4.3.0", "@inquirer/confirm": "^5.1.19", "@inquirer/editor": "^4.2.21", "@inquirer/expand": "^4.0.21", "@inquirer/input": "^4.2.5", "@inquirer/number": "^3.0.21", "@inquirer/password": "^4.0.21", "@inquirer/rawlist": "^4.1.9", "@inquirer/search": "^3.2.0", "@inquirer/select": "^4.4.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-X7/+dG9SLpSzRkwgG5/xiIzW0oMrV3C0HOa7YHG1WnrLK+vCQHfte4k/T80059YBdei29RBC3s+pSMvPJDU9/A=="],
+    "@inquirer/prompts": ["@inquirer/prompts@7.10.1", "", { "dependencies": { "@inquirer/checkbox": "^4.3.2", "@inquirer/confirm": "^5.1.21", "@inquirer/editor": "^4.2.23", "@inquirer/expand": "^4.0.23", "@inquirer/input": "^4.3.1", "@inquirer/number": "^3.0.23", "@inquirer/password": "^4.0.23", "@inquirer/rawlist": "^4.1.11", "@inquirer/search": "^3.2.2", "@inquirer/select": "^4.4.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg=="],
 
-    "@inquirer/rawlist": ["@inquirer/rawlist@4.1.9", "", { "dependencies": { "@inquirer/core": "^10.3.0", "@inquirer/type": "^3.0.9", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-AWpxB7MuJrRiSfTKGJ7Y68imYt8P9N3Gaa7ySdkFj1iWjr6WfbGAhdZvw/UnhFXTHITJzxGUI9k8IX7akAEBCg=="],
+    "@inquirer/rawlist": ["@inquirer/rawlist@4.1.11", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/type": "^3.0.10", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw=="],
 
-    "@inquirer/search": ["@inquirer/search@3.2.0", "", { "dependencies": { "@inquirer/core": "^10.3.0", "@inquirer/figures": "^1.0.14", "@inquirer/type": "^3.0.9", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-a5SzB/qrXafDX1Z4AZW3CsVoiNxcIYCzYP7r9RzrfMpaLpB+yWi5U8BWagZyLmwR0pKbbL5umnGRd0RzGVI8bQ=="],
+    "@inquirer/search": ["@inquirer/search@3.2.2", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA=="],
 
-    "@inquirer/select": ["@inquirer/select@4.4.0", "", { "dependencies": { "@inquirer/ansi": "^1.0.1", "@inquirer/core": "^10.3.0", "@inquirer/figures": "^1.0.14", "@inquirer/type": "^3.0.9", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-kaC3FHsJZvVyIjYBs5Ih8y8Bj4P/QItQWrZW22WJax7zTN+ZPXVGuOM55vzbdCP9zKUiBd9iEJVdesujfF+cAA=="],
+    "@inquirer/select": ["@inquirer/select@4.4.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/core": "^10.3.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w=="],
 
-    "@inquirer/type": ["@inquirer/type@3.0.9", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-QPaNt/nmE2bLGQa9b7wwyRJoLZ7pN6rcyXvzU0YCmivmJyq1BVo94G98tStRWkoD1RgDX5C+dPlhhHzNdu/W/w=="],
+    "@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
 
     "@manypkg/find-root": ["@manypkg/find-root@1.1.0", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@types/node": "^12.7.1", "find-up": "^4.1.0", "fs-extra": "^8.1.0" } }, "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="],
 
@@ -135,49 +136,47 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@types/bun": ["@types/bun@1.3.1", "", { "dependencies": { "bun-types": "1.3.1" } }, "sha512-4jNMk2/K9YJtfqwoAa28c8wK+T7nvJFOjxI4h/7sORWcypRNxBpr+TPNaCfVWq70tLCJsqoFwcf0oI0JU/fvMQ=="],
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@22.13.14", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w=="],
+    "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
-    "@types/react": ["@types/react@19.2.2", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA=="],
-
-    "@types/yargs": ["@types/yargs@17.0.34", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-KExbHVa92aJpw9WDQvzBaGVE2/Pz+pLZQloT2hjL8IqsZnV62rlPOYvNnLmf/L2dyllfVUOVBj64M0z/46eR2A=="],
+    "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
 
     "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
 
-    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.46.2", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.46.2", "@typescript-eslint/type-utils": "8.46.2", "@typescript-eslint/utils": "8.46.2", "@typescript-eslint/visitor-keys": "8.46.2", "graphemer": "^1.4.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.46.2", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-ZGBMToy857/NIPaaCucIUQgqueOiq7HeAKkhlvqVV4lm089zUFW6ikRySx2v+cAhKeUCPuWVHeimyk6Dw1iY3w=="],
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.58.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.58.0", "@typescript-eslint/type-utils": "8.58.0", "@typescript-eslint/utils": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.58.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg=="],
 
-    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.46.2", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.46.2", "@typescript-eslint/types": "8.46.2", "@typescript-eslint/typescript-estree": "8.46.2", "@typescript-eslint/visitor-keys": "8.46.2", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g=="],
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.58.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.58.0", "@typescript-eslint/types": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA=="],
 
-    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.46.2", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.46.2", "@typescript-eslint/types": "^8.46.2", "debug": "^4.3.4" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-PULOLZ9iqwI7hXcmL4fVfIsBi6AN9YxRc0frbvmg8f+4hQAjQ5GYNKK0DIArNo+rOKmR/iBYwkpBmnIwin4wBg=="],
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.58.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.58.0", "@typescript-eslint/types": "^8.58.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg=="],
 
-    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.46.2", "", { "dependencies": { "@typescript-eslint/types": "8.46.2", "@typescript-eslint/visitor-keys": "8.46.2" } }, "sha512-LF4b/NmGvdWEHD2H4MsHD8ny6JpiVNDzrSZr3CsckEgCbAGZbYM4Cqxvi9L+WqDMT+51Ozy7lt2M+d0JLEuBqA=="],
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0" } }, "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ=="],
 
-    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.46.2", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-a7QH6fw4S57+F5y2FIxxSDyi5M4UfGF+Jl1bCGd7+L4KsaUY80GsiF/t0UoRFDHAguKlBaACWJRmdrc6Xfkkag=="],
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.58.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A=="],
 
-    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.46.2", "", { "dependencies": { "@typescript-eslint/types": "8.46.2", "@typescript-eslint/typescript-estree": "8.46.2", "@typescript-eslint/utils": "8.46.2", "debug": "^4.3.4", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-HbPM4LbaAAt/DjxXaG9yiS9brOOz6fabal4uvUmaUYe6l3K1phQDMQKBRUrr06BQkxkvIZVVHttqiybM9nJsLA=="],
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0", "@typescript-eslint/utils": "8.58.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg=="],
 
-    "@typescript-eslint/types": ["@typescript-eslint/types@8.46.2", "", {}, "sha512-lNCWCbq7rpg7qDsQrd3D6NyWYu+gkTENkG5IKYhUIcxSb59SQC/hEQ+MrG4sTgBVghTonNWq42bA/d4yYumldQ=="],
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.58.0", "", {}, "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww=="],
 
-    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.46.2", "", { "dependencies": { "@typescript-eslint/project-service": "8.46.2", "@typescript-eslint/tsconfig-utils": "8.46.2", "@typescript-eslint/types": "8.46.2", "@typescript-eslint/visitor-keys": "8.46.2", "debug": "^4.3.4", "fast-glob": "^3.3.2", "is-glob": "^4.0.3", "minimatch": "^9.0.4", "semver": "^7.6.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-f7rW7LJ2b7Uh2EiQ+7sza6RDZnajbNbemn54Ob6fRwQbgcIn+GWfyuHDHRYgRoZu1P4AayVScrRW+YfbTvPQoQ=="],
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.58.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.58.0", "@typescript-eslint/tsconfig-utils": "8.58.0", "@typescript-eslint/types": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA=="],
 
-    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.46.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/scope-manager": "8.46.2", "@typescript-eslint/types": "8.46.2", "@typescript-eslint/typescript-estree": "8.46.2" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-sExxzucx0Tud5tE0XqR0lT0psBQvEpnpiul9XbGUB1QwpWJJAps1O/Z7hJxLGiZLBKMCutjTzDgmd1muEhBnVg=="],
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.58.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.58.0", "@typescript-eslint/types": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA=="],
 
-    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.46.2", "", { "dependencies": { "@typescript-eslint/types": "8.46.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-tUFMXI4gxzzMXt4xpGJEsBsTox0XbNQ1y94EwlD/CuZwFcQP79xfQqMhau9HsRc/J0cAPA/HZt1dZPtGn9V/7w=="],
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ=="],
 
-    "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
-    "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+    "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
-    "ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -189,19 +188,17 @@
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
-    "brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
+    "brace-expansion": ["brace-expansion@1.1.13", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "bun-types": ["bun-types@1.3.1", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-NMrcy7smratanWJ2mMXdpatalovtxVggkj11bScuWuiOoXTiKIu2eVS1/7qbyI/4yHedtsn175n4Sm4JcdHLXw=="],
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
-    "chardet": ["chardet@2.1.0", "", {}, "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA=="],
-
-    "ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
+    "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
 
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
@@ -219,9 +216,7 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
-    "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
-
-    "debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
@@ -229,13 +224,13 @@
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
-    "emoji-regex": ["emoji-regex@10.4.0", "", {}, "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="],
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "eslint": ["eslint@9.39.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.39.0", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-iy2GE3MHrYTL5lrCtMZ0X1KLEKKUjmK0kzwcnefhR66txcEmXZD2YWgR5GNdcEwkNx3a0siYkSvl0vIC+Svjmg=="],
+    "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
 
     "eslint-config-prettier": ["eslint-config-prettier@9.1.2", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ=="],
 
@@ -247,7 +242,7 @@
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
-    "esquery": ["esquery@1.6.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg=="],
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
 
     "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
 
@@ -265,7 +260,9 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
-    "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
+    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
@@ -275,11 +272,11 @@
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
-    "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
     "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
-    "get-east-asian-width": ["get-east-asian-width@1.3.0", "", {}, "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ=="],
+    "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -289,13 +286,11 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
-
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "human-id": ["human-id@4.1.1", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-3gKm/gCSUipeLsRYZbbdA1BD83lBoWUkZ7G9VFrhWPAU76KwYo5KR8V28bpoPm/ygy0x5/GCbpRQdY7VLYCoIg=="],
+    "human-id": ["human-id@4.1.3", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q=="],
 
-    "iconv-lite": ["iconv-lite@0.7.0", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ=="],
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -303,7 +298,7 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
-    "inquirer": ["inquirer@12.10.0", "", { "dependencies": { "@inquirer/ansi": "^1.0.1", "@inquirer/core": "^10.3.0", "@inquirer/prompts": "^7.9.0", "@inquirer/type": "^3.0.9", "mute-stream": "^2.0.0", "run-async": "^4.0.5", "rxjs": "^7.8.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-K/epfEnDBZj2Q3NMDcgXWZye3nhSPeoJnOh8lcKWrldw54UEZfS4EmAMsAsmVbl7qKi+vjAsy39Sz4fbgRMewg=="],
+    "inquirer": ["inquirer@12.11.1", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/core": "^10.3.2", "@inquirer/prompts": "^7.10.1", "@inquirer/type": "^3.0.10", "mute-stream": "^2.0.0", "run-async": "^4.0.6", "rxjs": "^7.8.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -323,7 +318,7 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
-    "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
@@ -351,7 +346,7 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
-    "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
@@ -371,7 +366,7 @@
 
     "p-filter": ["p-filter@2.1.0", "", { "dependencies": { "p-map": "^2.0.0" } }, "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw=="],
 
-    "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
@@ -391,25 +386,23 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
-    "prettier": ["prettier@3.6.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ=="],
+    "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "quansync": ["quansync@0.2.10", "", {}, "sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A=="],
+    "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "read-yaml-file": ["read-yaml-file@1.1.0", "", { "dependencies": { "graceful-fs": "^4.1.5", "js-yaml": "^3.6.1", "pify": "^4.0.1", "strip-bom": "^3.0.0" } }, "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA=="],
 
     "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
-
-    "regenerator-runtime": ["regenerator-runtime@0.14.1", "", {}, "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="],
 
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
@@ -425,7 +418,7 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
-    "semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -443,7 +436,7 @@
 
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
-    "strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
@@ -453,9 +446,11 @@
 
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
 
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
-    "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ=="],
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -463,9 +458,9 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "typescript-eslint": ["typescript-eslint@8.46.2", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.46.2", "@typescript-eslint/parser": "8.46.2", "@typescript-eslint/typescript-estree": "8.46.2", "@typescript-eslint/utils": "8.46.2" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-vbw8bOmiuYNdzzV3lsiWv6sRwjyuKJMQqWulBOU7M0RrxedXledX8G8kBbQeiOYDnTfiXz0Y4081E1QMNB6iQg=="],
+    "typescript-eslint": ["typescript-eslint@8.58.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.58.0", "@typescript-eslint/parser": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0", "@typescript-eslint/utils": "8.58.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA=="],
 
-    "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
@@ -479,11 +474,9 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "yoctocolors-cjs": ["yoctocolors-cjs@2.1.2", "", {}, "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA=="],
+    "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
 
     "@changesets/apply-release-plan/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
-
-    "@changesets/parse/js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
 
     "@changesets/write/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
@@ -503,7 +496,9 @@
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
-    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
     "enquirer/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -515,25 +510,23 @@
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
-    "log-symbols/chalk": ["chalk@5.4.1", "", {}, "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w=="],
+    "log-symbols/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
-    "ora/chalk": ["chalk@5.4.1", "", {}, "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w=="],
+    "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+    "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "read-yaml-file/js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
+    "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "@changesets/parse/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
-
     "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
-    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "enquirer/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -544,5 +537,9 @@
     "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "@manypkg/find-root/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "@manypkg/find-root/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
   }
 }

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -5,8 +5,13 @@ coverage = true
 coverageSkipTestFiles = true
 
 coveragePathIgnorePatterns = [
-    "**/*.test.ts",
-    "test/**",
+    "lib/defaults/**",
+    "test/utils/*.ts",
+    "test/fixtures/**/**.ts",
+    "dist/**/*.js",
+    "dist/**/*.ts",
+    "../**/*.ts",
+    "../**/*.js"
 ]
 
 [test.reporter]

--- a/lib/codeBuilder/ControllerHandler.ts
+++ b/lib/codeBuilder/ControllerHandler.ts
@@ -8,7 +8,14 @@ export class ControllerHandler {
   }
 
   public addController(controllerName: string, controllerPath: string | null) {
-    const controller = `\n@Controller(${controllerPath ? controllerPath : ''})\n export class ${controllerName}{\n\n}`;
+    const controller = [
+      '',
+      `@Controller(${controllerPath ?? ''})`,
+      `export class ${controllerName} {`,
+      '',
+      '}',
+      '',
+    ].join('\n');
 
     this._code = this._code + controller;
 
@@ -16,7 +23,13 @@ export class ControllerHandler {
   }
 
   public addGetRouterToController(controllerName: string, path: string, name: string) {
-    const controller = `\n\n\t@Get('/${path}')\n\tpublic async ${name}(context:Context){\n\t\treturn context.send("Hello asena");\n\t}`;
+    const controller = [
+      '',
+      `  @Get('/${path}')`,
+      `  public async ${name}(context: Context) {`,
+      `    return context.send('Hello asena');`,
+      '  }',
+    ].join('\n');
 
     const controllerEndIndex = RegexHelper.getElementIndexByName(this._code, 'Controller', controllerName);
 

--- a/lib/codeBuilder/MiddlewareHandler.ts
+++ b/lib/codeBuilder/MiddlewareHandler.ts
@@ -8,7 +8,7 @@ export class MiddlewareHandler {
   }
 
   public addMiddleware(serviceName: string) {
-    const service = `\n@Middleware()\nexport class ${serviceName} extends MiddlewareService{\n\n}`;
+    const service = `\n@Middleware()\nexport class ${serviceName} extends MiddlewareService {\n\n}`;
 
     this._code = this._code + service;
 
@@ -16,7 +16,7 @@ export class MiddlewareHandler {
   }
 
   public addDefaultHandle(serviceName: string) {
-    const handle = `\n\n\tpublic handle(context:Context, next:Function) {\n\t\tcontext.setValue("testValue","test");\n\n\t\tnext();\n\t}`;
+    const handle = `\n\n  public handle(context: Context, next: Function) {\n    context.setValue('testValue', 'test');\n    next();\n  }`;
 
     const controllerEndIndex = RegexHelper.getElementIndexByName(this._code, 'Middleware', serviceName);
 

--- a/lib/codeBuilder/ServerConfigHandler.ts
+++ b/lib/codeBuilder/ServerConfigHandler.ts
@@ -6,8 +6,7 @@ export class ServerConfigHandler {
   }
 
   public addConfigClass(className: string) {
-    const configClass = `
-@Config()
+    const configClass = `\n@Config()
 export class ${className} extends ConfigService {
 
   public onError(error: Error, context: Context): Response | Promise<Response> {

--- a/lib/codeBuilder/ValidatorHandler.ts
+++ b/lib/codeBuilder/ValidatorHandler.ts
@@ -22,37 +22,37 @@ export class ValidatorHandler {
    * @param validatorName Name of the validator class
    */
   public addExampleSchema(validatorName: string) {
-    const exampleSchema = `\t/**
-\t * Validates JSON body data
-\t * @returns Zod schema for request body validation
-\t */
-\tjson() {
-\t\treturn z.object({
-\t\t\tname: z.string().min(3, 'Name must be at least 3 characters'),
-\t\t\temail: z.string().email('Invalid email format'),
-\t\t});
-\t}
+    const exampleSchema = `  /**
+   * Validates JSON body data
+   * @returns Zod schema for request body validation
+   */
+  json() {
+    return z.object({
+      name: z.string().min(3, 'Name must be at least 3 characters'),
+      email: z.string().email('Invalid email format'),
+    });
+  }
 
-\t/**
-\t * Validates query parameters (optional)
-\t * Uncomment to use query validation
-\t */
-\t// query() {
-\t//   return z.object({
-\t//     page: z.string().transform(Number).pipe(z.number().min(1)),
-\t//     limit: z.string().transform(Number).pipe(z.number().max(100)),
-\t//   });
-\t// }
+  /**
+   * Validates query parameters (optional)
+   * Uncomment to use query validation
+   */
+  // query() {
+  //   return z.object({
+  //     page: z.string().transform(Number).pipe(z.number().min(1)),
+  //     limit: z.string().transform(Number).pipe(z.number().max(100)),
+  //   });
+  // }
 
-\t/**
-\t * Validates URL parameters (optional)
-\t * Uncomment to use param validation
-\t */
-\t// param() {
-\t//   return z.object({
-\t//     id: z.string().uuid('Invalid ID format'),
-\t//   });
-\t// }
+  /**
+   * Validates URL parameters (optional)
+   * Uncomment to use param validation
+   */
+  // param() {
+  //   return z.object({
+  //     id: z.string().uuid('Invalid ID format'),
+  //   });
+  // }
 `;
 
     // Find the closing brace of the validator class using a custom regex

--- a/lib/codeBuilder/WebSocketHandler.ts
+++ b/lib/codeBuilder/WebSocketHandler.ts
@@ -6,8 +6,7 @@ export class WebSocketHandler {
   }
 
   public addWebSocketNamespace(className: string, path: string) {
-    const websocketClass = `
-@WebSocket({ path: '${path}', name: '${className}' })
+    const websocketClass = `\n@WebSocket({ path: '${path}', name: '${className}' })
 export class ${className} extends AsenaWebSocketService {
 
   protected async onOpen(ws: Socket): Promise<void> {

--- a/lib/commands/Commands.ts
+++ b/lib/commands/Commands.ts
@@ -11,7 +11,7 @@ export class Commands {
   public constructor() {
     this.program.name('asena');
 
-    this.program.version('0.6.0');
+    this.program.version('0.7.0');
 
     this.program.addCommand(new Create().command());
 

--- a/lib/commands/Create.ts
+++ b/lib/commands/Create.ts
@@ -7,6 +7,7 @@ import { AsenaLoggerCreator, AsenaServerHandler, ControllerHandler, ImportHandle
 import {
   ESLINT_INSTALLATIONS,
   ESLINT_WITH_PRETTIER_INSTALLATIONS,
+  GITIGNORE,
   PRETTIER,
   PRETTIER_IGNORE,
   PRETTIER_INSTALLATIONS,
@@ -38,6 +39,7 @@ export class Create implements BaseCommand {
       .option('--no-eslint', 'Skip ESLint setup')
       .option('--prettier', 'Setup Prettier')
       .option('--no-prettier', 'Skip Prettier setup')
+      .option('--skip-install', 'Skip dependency installation (useful for monorepos)')
       .action(async (projectName, options) => {
         const spinner = ora('Creating asena project...');
 
@@ -61,16 +63,18 @@ export class Create implements BaseCommand {
   private async create(currentFolder: boolean, spinner: Ora, options?: any, projectName?: string) {
     this.preference = await this.askQuestions(currentFolder, options, projectName);
 
-    // If creating in current folder, set project name to "myApp"
+    const skipInstall = options?.skipInstall === true;
+
+    // If creating in current folder, use the current folder name as project name
     if (currentFolder) {
-      this.preference.projectName = 'myApp';
+      this.preference.projectName = path.basename(process.cwd());
     }
 
     spinner.start();
 
     const projectPath = currentFolder ? process.cwd() : path.resolve(process.cwd(), this.preference.projectName);
 
-    await this.createPackageJson(projectPath);
+    await this.createPackageJson(projectPath, skipInstall);
 
     await this.createDefaultController(projectPath);
 
@@ -80,15 +84,31 @@ export class Create implements BaseCommand {
 
     if (!currentFolder) process.chdir(projectPath);
 
-    await this.installPreRequests();
+    if (!skipInstall) {
+      await this.installPreRequests();
+    }
 
-    if (this.preference.eslint) await this.installAndCreateEslint();
+    if (this.preference.eslint) {
+      if (skipInstall) {
+        await this.createEslintConfig();
+      } else {
+        await this.installAndCreateEslint();
+      }
+    }
 
-    if (this.preference.prettier) await this.installAndCreatePrettier();
+    if (this.preference.prettier) {
+      if (skipInstall) {
+        await this.createPrettierConfig();
+      } else {
+        await this.installAndCreatePrettier();
+      }
+    }
 
     await this.createTsConfig();
 
-    await new Init().exec(this.preference.adapter);
+    await this.createGitignore(projectPath);
+
+    await new Init().exec(this.preference.adapter, skipInstall);
   }
 
   private async createDefaultIndexFile(projectPath: string) {
@@ -146,8 +166,10 @@ export class Create implements BaseCommand {
     await Bun.write(projectPath + '/src/controllers/AsenaController.ts', controllerCode);
   }
 
-  private async createPackageJson(projectPath: string) {
+  private async createPackageJson(projectPath: string, skipInstall = false) {
     const scripts: Record<string, string> = {
+      dev: 'asena dev start',
+      'dev:hot': 'bun run --hot src/index.ts',
       start: 'bun src/index.ts',
       build: 'asena build',
       'start:prod': 'bun run dist/index.js',
@@ -171,11 +193,51 @@ export class Create implements BaseCommand {
       scripts['check:fix'] = 'bun run lint:fix && bun run format';
     }
 
-    const packageJson = {
+    const packageJson: Record<string, any> = {
       name: this.preference.projectName,
       module: 'src/index.ts',
       scripts,
     };
+
+    // When skip-install is set, write dependencies directly to package.json
+    // so the user can run `bun install` later
+    if (skipInstall) {
+      const adapterPackage = getAdapterPackage(this.preference.adapter);
+
+      const dependencies: Record<string, string> = {
+        '@asenajs/asena': 'latest',
+        [adapterPackage]: 'latest',
+      };
+
+      if (this.preference.logger) {
+        dependencies['@asenajs/asena-logger'] = 'latest';
+      }
+
+      const devDependencies: Record<string, string> = {
+        '@types/bun': 'latest',
+        typescript: 'latest',
+        '@asenajs/asena-cli': 'latest',
+      };
+
+      if (this.preference.eslint) {
+        for (const pkg of ESLINT_INSTALLATIONS) {
+          devDependencies[pkg] = 'latest';
+        }
+
+        if (this.preference.prettier) {
+          for (const pkg of ESLINT_WITH_PRETTIER_INSTALLATIONS) {
+            devDependencies[pkg] = 'latest';
+          }
+        }
+      }
+
+      if (this.preference.prettier) {
+        devDependencies['prettier'] = 'latest';
+      }
+
+      packageJson['dependencies'] = dependencies;
+      packageJson['devDependencies'] = devDependencies;
+    }
 
     await Bun.write(projectPath + '/package.json', JSON.stringify(packageJson, null, 2));
   }
@@ -277,6 +339,17 @@ ${usePrettier ? '\n  // Prettier config to disable conflicting rules\n  eslintCo
 `;
   }
 
+  private async createEslintConfig() {
+    const eslintConfig = this.getEslintConfig();
+
+    await Bun.write(process.cwd() + '/eslint.config.cjs', eslintConfig);
+  }
+
+  private async createPrettierConfig() {
+    await Bun.write(process.cwd() + '/.prettierrc.js', PRETTIER);
+    await Bun.write(process.cwd() + '/.prettierignore', PRETTIER_IGNORE);
+  }
+
   private async installAndCreateEslint() {
     // Install base ESLint packages
     const output = await $`bun add -D ${ESLINT_INSTALLATIONS}`.quiet();
@@ -307,6 +380,10 @@ ${usePrettier ? '\n  // Prettier config to disable conflicting rules\n  eslintCo
 
   private async createTsConfig() {
     await Bun.write(process.cwd() + '/tsconfig.json', TSCONFIG);
+  }
+
+  private async createGitignore(projectPath: string) {
+    await Bun.write(path.join(projectPath, '.gitignore'), GITIGNORE);
   }
 
   private async askQuestions(

--- a/lib/commands/Generate.ts
+++ b/lib/commands/Generate.ts
@@ -131,7 +131,7 @@ export class Generate implements BaseCommand {
     const importType = await getImportType();
 
     const serviceCode =
-      new ImportHandler('', importType).importToCode({ '@asenajs/asena/server': ['Service'] }, importType) +
+      new ImportHandler('', importType).importToCode({ '@asenajs/asena/decorators': ['Service'] }, importType) +
       new ServiceHandler('').addService(serviceName).code;
 
     await this.generate(serviceCode, 'services', serviceName);

--- a/lib/commands/Init.ts
+++ b/lib/commands/Init.ts
@@ -24,7 +24,7 @@ export class Init implements BaseCommand {
       });
   }
 
-  public async exec(adapter?: AdapterType) {
+  public async exec(adapter?: AdapterType, skipInstall = false) {
     if (!isAsenaConfigExists()) {
       // 1. Use provided adapter or ask user which adapter to use
       const selectedAdapter = adapter || (await this.askAdapterQuestion()).adapter;
@@ -35,8 +35,8 @@ export class Init implements BaseCommand {
         suffixes: true, // Default: use standard suffixes (Controller, Service, etc.)
       });
 
-      // 3. Install CLI package if needed
-      if (!(await getAsenaCliVersion())) {
+      // 3. Install CLI package if needed (skip if --skip-install was used)
+      if (!skipInstall && !(await getAsenaCliVersion())) {
         const asenaCliVersion = await $`asena --version`.quiet().text();
 
         await $`bun add -D @asenajs/asena-cli@${asenaCliVersion}`.quiet();

--- a/lib/constants/adapters.ts
+++ b/lib/constants/adapters.ts
@@ -12,8 +12,8 @@ export const HONO_ROOT_IMPORTS: ImportsByFiles = {
  * Hono Adapter imports for controller files
  */
 export const HONO_CONTROLLER_IMPORTS: ImportsByFiles = {
-  '@asenajs/asena/server': ['Controller'],
-  '@asenajs/asena/web': ['Get'],
+  '@asenajs/asena/decorators': ['Controller'],
+  '@asenajs/asena/decorators/http': ['Get'],
   '@asenajs/hono-adapter': ['type Context'],
 };
 
@@ -21,7 +21,7 @@ export const HONO_CONTROLLER_IMPORTS: ImportsByFiles = {
  * Hono Adapter imports for middleware files
  */
 export const HONO_MIDDLEWARE_IMPORTS: ImportsByFiles = {
-  '@asenajs/asena/server': ['Middleware'],
+  '@asenajs/asena/decorators': ['Middleware'],
   '@asenajs/hono-adapter': ['type Context', 'MiddlewareService'],
 };
 
@@ -37,8 +37,8 @@ export const ERGENECORE_ROOT_IMPORTS: ImportsByFiles = {
  * Ergenecore Adapter imports for controller files
  */
 export const ERGENECORE_CONTROLLER_IMPORTS: ImportsByFiles = {
-  '@asenajs/asena/server': ['Controller'],
-  '@asenajs/asena/web': ['Get'],
+  '@asenajs/asena/decorators': ['Controller'],
+  '@asenajs/asena/decorators/http': ['Get'],
   '@asenajs/ergenecore': ['type Context'],
 };
 
@@ -46,7 +46,7 @@ export const ERGENECORE_CONTROLLER_IMPORTS: ImportsByFiles = {
  * Ergenecore Adapter imports for middleware files
  */
 export const ERGENECORE_MIDDLEWARE_IMPORTS: ImportsByFiles = {
-  '@asenajs/asena/server': ['Middleware'],
+  '@asenajs/asena/decorators': ['Middleware'],
   '@asenajs/ergenecore': ['type Context', 'MiddlewareService'],
 };
 
@@ -54,7 +54,7 @@ export const ERGENECORE_MIDDLEWARE_IMPORTS: ImportsByFiles = {
  * Hono Adapter imports for config files (ServerConfig)
  */
 export const HONO_CONFIG_IMPORTS: ImportsByFiles = {
-  '@asenajs/asena/server': ['Config'],
+  '@asenajs/asena/decorators': ['Config'],
   '@asenajs/hono-adapter': ['ConfigService', 'type Context'],
 };
 
@@ -62,7 +62,7 @@ export const HONO_CONFIG_IMPORTS: ImportsByFiles = {
  * Ergenecore Adapter imports for config files (ServerConfig)
  */
 export const ERGENECORE_CONFIG_IMPORTS: ImportsByFiles = {
-  '@asenajs/asena/server': ['Config'],
+  '@asenajs/asena/decorators': ['Config'],
   '@asenajs/ergenecore': ['ConfigService', 'type Context'],
 };
 
@@ -70,7 +70,7 @@ export const ERGENECORE_CONFIG_IMPORTS: ImportsByFiles = {
  * Hono Adapter imports for validator files
  */
 export const HONO_VALIDATOR_IMPORTS: ImportsByFiles = {
-  '@asenajs/asena/server': ['Middleware'],
+  '@asenajs/asena/decorators': ['Middleware'],
   '@asenajs/hono-adapter': ['ValidationService'],
   zod: ['z'],
 };
@@ -79,7 +79,7 @@ export const HONO_VALIDATOR_IMPORTS: ImportsByFiles = {
  * Ergenecore Adapter imports for validator files
  */
 export const ERGENECORE_VALIDATOR_IMPORTS: ImportsByFiles = {
-  '@asenajs/asena/server': ['Middleware'],
+  '@asenajs/asena/decorators': ['Middleware'],
   '@asenajs/ergenecore': ['ValidationService'],
   zod: ['z'],
 };
@@ -88,7 +88,7 @@ export const ERGENECORE_VALIDATOR_IMPORTS: ImportsByFiles = {
  * WebSocket namespace imports (adapter-agnostic)
  */
 export const WEBSOCKET_IMPORTS: ImportsByFiles = {
-  '@asenajs/asena/server': ['WebSocket'],
+  '@asenajs/asena/decorators': ['WebSocket'],
   '@asenajs/asena/web-socket': ['AsenaWebSocketService', 'type Socket'],
 };
 

--- a/lib/constants/configSchema.ts
+++ b/lib/constants/configSchema.ts
@@ -1,0 +1,63 @@
+/**
+ * JSON Schema for .asena/config.json
+ * Provides IDE autocomplete and validation support
+ */
+export const CONFIG_SCHEMA = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'Asena CLI Configuration',
+  description: 'Configuration file for AsenaJS CLI tool',
+  type: 'object',
+  properties: {
+    $schema: {
+      type: 'string',
+      description: 'JSON Schema reference',
+    },
+    adapter: {
+      type: 'string',
+      enum: ['hono', 'ergenecore'],
+      description: 'HTTP adapter to use for the project',
+    },
+    suffixes: {
+      description: 'Configure component naming suffixes',
+      oneOf: [
+        {
+          type: 'boolean',
+          description: 'Enable/disable all suffixes globally (true = use defaults, false = no suffixes)',
+        },
+        {
+          type: 'object',
+          description: 'Granular control per component type',
+          properties: {
+            controller: {
+              type: ['boolean', 'string'],
+              description: 'Controller suffix (true = "Controller", false = none, string = custom)',
+            },
+            service: {
+              type: ['boolean', 'string'],
+              description: 'Service suffix (true = "Service", false = none, string = custom)',
+            },
+            middleware: {
+              type: ['boolean', 'string'],
+              description: 'Middleware suffix (true = "Middleware", false = none, string = custom)',
+            },
+            validator: {
+              type: ['boolean', 'string'],
+              description: 'Validator suffix (true = "Validator", false = none, string = custom)',
+            },
+            config: {
+              type: ['boolean', 'string'],
+              description: 'Config suffix (true = "Config", false = none, string = custom)',
+            },
+            websocket: {
+              type: ['boolean', 'string'],
+              description: 'WebSocket suffix (true = "Namespace", false = none, string = custom)',
+            },
+          },
+          additionalProperties: false,
+        },
+      ],
+    },
+  },
+  required: ['adapter'],
+  additionalProperties: false,
+};

--- a/lib/constants/create.ts
+++ b/lib/constants/create.ts
@@ -103,3 +103,34 @@ pnpm-lock.yaml
 
 *.md
 `;
+
+export const GITIGNORE = `# Dependencies
+node_modules/
+
+# Build output
+dist/
+out/
+
+# Asena CLI
+.asena/
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE/Editor files
+.idea/
+.vscode/
+*.swp
+*.swo
+`;

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -4,3 +4,4 @@ export * from './create';
 export * from './file';
 export * from './init';
 export * from './adapters';
+export * from './configSchema';

--- a/lib/helpers/adapterConfigHelper.ts
+++ b/lib/helpers/adapterConfigHelper.ts
@@ -1,8 +1,10 @@
 import { $ } from 'bun';
 import type { AdapterConfig, AdapterType, ComponentType } from '../types';
+import { CONFIG_SCHEMA } from '../constants/configSchema';
 
 const CONFIG_DIR = '.asena';
 const CONFIG_FILE = `${CONFIG_DIR}/config.json`;
+const SCHEMA_FILE = `${CONFIG_DIR}/config.schema.json`;
 
 /**
  * Default suffixes for each component type
@@ -56,7 +58,16 @@ export async function writeAdapterConfig(config: AdapterConfig): Promise<void> {
   // Create .asena directory if it doesn't exist (mkdir -p)
   await $`mkdir -p ${CONFIG_DIR}`.quiet();
 
-  await Bun.write(CONFIG_FILE, JSON.stringify(config, null, 2));
+  // Add $schema reference for IDE autocomplete/validation
+  const configWithSchema: AdapterConfig = {
+    $schema: './config.schema.json',
+    ...config,
+  };
+
+  await Promise.all([
+    Bun.write(CONFIG_FILE, JSON.stringify(configWithSchema, null, 2)),
+    Bun.write(SCHEMA_FILE, JSON.stringify(CONFIG_SCHEMA, null, 2)),
+  ]);
 }
 
 /**

--- a/lib/types/adapterConfig.ts
+++ b/lib/types/adapterConfig.ts
@@ -32,6 +32,7 @@ export interface SuffixSettings {
  * CLI configuration stored in .asena/config.json
  */
 export interface AdapterConfig {
+  $schema?: string;
   adapter: AdapterType;
   /**
    * Suffix configuration

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asenajs/asena-cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": "LibirSoft",
   "license": "MIT",
   "bin": {
@@ -33,24 +33,24 @@
     "url": "https://github.com/AsenaJs/Asena-cli"
   },
   "dependencies": {
-    "@asenajs/asena": "^0.6.0",
-    "@changesets/cli": "^2.29.7",
+    "@asenajs/asena": "^0.7.0",
+    "@changesets/cli": "^2.30.0",
     "commander": "^12.1.0",
-    "inquirer": "^12.10.0",
+    "inquirer": "^12.11.1",
     "ora": "^8.2.0",
     "reflect-metadata": "^0.2.2",
     "strip-json-comments": "^5.0.3"
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "@types/yargs": "^17.0.34",
-    "@typescript-eslint/eslint-plugin": "^8.46.2",
-    "@typescript-eslint/parser": "^8.46.2",
-    "eslint": "^9.39.0",
+    "@types/yargs": "^17.0.35",
+    "@typescript-eslint/eslint-plugin": "^8.58.0",
+    "@typescript-eslint/parser": "^8.58.0",
+    "eslint": "^9.39.4",
     "eslint-config-prettier": "^9.1.2",
-    "prettier": "^3.6.2",
+    "prettier": "^3.8.1",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.46.2"
+    "typescript-eslint": "^8.58.0"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/test/codeBuilder/ControllerHandler.test.ts
+++ b/test/codeBuilder/ControllerHandler.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'bun:test';
+import { ControllerHandler } from '../../lib/codeBuilder/ControllerHandler';
+
+describe('ControllerHandler', () => {
+  describe('addController', () => {
+    it('should create controller with correct structure', () => {
+      const handler = new ControllerHandler('');
+      const result = handler.addController('UserController', "'/users'");
+
+      expect(result.code).toContain("@Controller('/users')");
+      expect(result.code).toContain('export class UserController {');
+    });
+
+    it('should create controller without path', () => {
+      const handler = new ControllerHandler('');
+      const result = handler.addController('UserController', null);
+
+      expect(result.code).toContain('@Controller()');
+      expect(result.code).toContain('export class UserController {');
+    });
+
+    it('should use 2-space indentation, not tabs', () => {
+      const handler = new ControllerHandler('');
+      const result = handler.addController('TestController', null);
+
+      expect(result.code).not.toContain('\t');
+    });
+
+    it('should have space before opening brace', () => {
+      const handler = new ControllerHandler('');
+      const result = handler.addController('TestController', null);
+
+      expect(result.code).toContain('TestController {');
+      expect(result.code).not.toMatch(/TestController\{/);
+    });
+
+    it('should not have extra space before export keyword', () => {
+      const handler = new ControllerHandler('');
+      const result = handler.addController('TestController', null);
+
+      expect(result.code).toContain('\nexport class');
+      expect(result.code).not.toContain('\n export class');
+    });
+  });
+
+  describe('addGetRouterToController', () => {
+    it('should use 2-space indentation, not tabs', () => {
+      const handler = new ControllerHandler('');
+      handler.addController('TestController', null);
+      const code = handler.addGetRouterToController('TestController', 'users', 'getUsers');
+
+      expect(code).not.toContain('\t');
+    });
+
+    it('should use single quotes', () => {
+      const handler = new ControllerHandler('');
+      handler.addController('TestController', null);
+      const code = handler.addGetRouterToController('TestController', 'users', 'getUsers');
+
+      expect(code).toContain("@Get('/users')");
+      expect(code).toContain("'Hello asena'");
+      expect(code).not.toContain('"Hello asena"');
+    });
+
+    it('should have proper spacing in method signature', () => {
+      const handler = new ControllerHandler('');
+      handler.addController('TestController', null);
+      const code = handler.addGetRouterToController('TestController', 'users', 'getUsers');
+
+      expect(code).toContain('context: Context');
+      expect(code).not.toContain('context:Context');
+    });
+  });
+});

--- a/test/codeBuilder/ImportHandler.test.ts
+++ b/test/codeBuilder/ImportHandler.test.ts
@@ -7,7 +7,7 @@ describe('ImportHandler', () => {
     it('should parse existing ES6 imports from code', () => {
       const code = `
 import { AsenaServer } from '@asenajs/asena';
-import { Controller } from '@asenajs/asena/server';
+import { Controller } from '@asenajs/asena/decorators';
 
 const x = 1;
 `;
@@ -22,7 +22,7 @@ const x = 1;
     it('should parse existing CommonJS requires from code', () => {
       const code = `
 const { AsenaServer } = require('@asenajs/asena');
-const { Controller } = require('@asenajs/asena/server');
+const { Controller } = require('@asenajs/asena/decorators');
 
 const x = 1;
 `;
@@ -283,7 +283,7 @@ import {
     it('should return all imports as array', () => {
       const code = `
 import { AsenaServer } from '@asenajs/asena';
-import { Controller } from '@asenajs/asena/server';
+import { Controller } from '@asenajs/asena/decorators';
 `;
       const handler = new ImportHandler(code, ImportType.IMPORT);
       const imports = handler.getImports;

--- a/test/codeBuilder/MiddlewareHandler.test.ts
+++ b/test/codeBuilder/MiddlewareHandler.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'bun:test';
+import { MiddlewareHandler } from '../../lib/codeBuilder/MiddlewareHandler';
+
+describe('MiddlewareHandler', () => {
+  describe('addMiddleware', () => {
+    it('should create middleware with correct structure', () => {
+      const handler = new MiddlewareHandler('');
+      const result = handler.addMiddleware('AuthMiddleware');
+
+      expect(result.code).toContain('@Middleware()');
+      expect(result.code).toContain('export class AuthMiddleware extends MiddlewareService {');
+    });
+
+    it('should have space before opening brace', () => {
+      const handler = new MiddlewareHandler('');
+      const result = handler.addMiddleware('AuthMiddleware');
+
+      expect(result.code).toContain('MiddlewareService {');
+      expect(result.code).not.toMatch(/MiddlewareService\{/);
+    });
+  });
+
+  describe('addDefaultHandle', () => {
+    it('should use 2-space indentation, not tabs', () => {
+      const handler = new MiddlewareHandler('');
+      handler.addMiddleware('AuthMiddleware');
+      handler.addDefaultHandle('AuthMiddleware');
+
+      expect(handler.code).not.toContain('\t');
+    });
+
+    it('should use single quotes', () => {
+      const handler = new MiddlewareHandler('');
+      handler.addMiddleware('AuthMiddleware');
+      handler.addDefaultHandle('AuthMiddleware');
+
+      expect(handler.code).toContain("'testValue'");
+      expect(handler.code).toContain("'test'");
+      expect(handler.code).not.toContain('"testValue"');
+      expect(handler.code).not.toContain('"test"');
+    });
+
+    it('should have proper spacing in method signature', () => {
+      const handler = new MiddlewareHandler('');
+      handler.addMiddleware('AuthMiddleware');
+      handler.addDefaultHandle('AuthMiddleware');
+
+      expect(handler.code).toContain('context: Context');
+      expect(handler.code).toContain('next: Function');
+    });
+
+    it('should not have double newline before next()', () => {
+      const handler = new MiddlewareHandler('');
+      handler.addMiddleware('AuthMiddleware');
+      handler.addDefaultHandle('AuthMiddleware');
+
+      expect(handler.code).not.toContain(';\n\n    next()');
+    });
+  });
+});

--- a/test/codeBuilder/ServerConfigHandler.test.ts
+++ b/test/codeBuilder/ServerConfigHandler.test.ts
@@ -30,6 +30,14 @@ describe('ServerConfigHandler', () => {
     expect(result.code).not.toContain('ServerConfig');
   });
 
+  it('should not start with leading blank line when appended to empty code', () => {
+    const handler = new ServerConfigHandler('');
+    const result = handler.addConfigClass('ServerConfig');
+
+    // Should start with \n (for separation) then directly @Config, not \n\n
+    expect(result.code).not.toMatch(/^\n\n/);
+  });
+
   it('should append to existing code', () => {
     const existingCode = '// Existing code\n';
     const handler = new ServerConfigHandler(existingCode);

--- a/test/codeBuilder/ValidatorHandler.test.ts
+++ b/test/codeBuilder/ValidatorHandler.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'bun:test';
+import { ValidatorHandler } from '../../lib/codeBuilder/ValidatorHandler';
+
+describe('ValidatorHandler', () => {
+  describe('addValidator', () => {
+    it('should create validator with correct structure', () => {
+      const handler = new ValidatorHandler('');
+      const result = handler.addValidator('UserValidator');
+
+      expect(result.code).toContain('@Middleware({ validator: true })');
+      expect(result.code).toContain('export class UserValidator extends ValidationService {');
+    });
+  });
+
+  describe('addExampleSchema', () => {
+    it('should use 2-space indentation, not tabs', () => {
+      const handler = new ValidatorHandler('');
+      handler.addValidator('UserValidator');
+      handler.addExampleSchema('UserValidator');
+
+      expect(handler.code).not.toContain('\t');
+    });
+
+    it('should contain json() method', () => {
+      const handler = new ValidatorHandler('');
+      handler.addValidator('UserValidator');
+      handler.addExampleSchema('UserValidator');
+
+      expect(handler.code).toContain('json()');
+      expect(handler.code).toContain('z.object');
+      expect(handler.code).toContain('z.string()');
+    });
+
+    it('should contain commented query and param methods', () => {
+      const handler = new ValidatorHandler('');
+      handler.addValidator('UserValidator');
+      handler.addExampleSchema('UserValidator');
+
+      expect(handler.code).toContain('// query()');
+      expect(handler.code).toContain('// param()');
+    });
+
+    it('should use consistent 2-space indentation for all schema lines', () => {
+      const handler = new ValidatorHandler('');
+      handler.addValidator('UserValidator');
+      handler.addExampleSchema('UserValidator');
+
+      const lines = handler.code.split('\n');
+      const indentedLines = lines.filter((l) => l.startsWith('  ') || l.startsWith('//'));
+
+      for (const line of indentedLines) {
+        expect(line).not.toMatch(/^\t/);
+      }
+    });
+  });
+});

--- a/test/codeBuilder/WebSocketHandler.test.ts
+++ b/test/codeBuilder/WebSocketHandler.test.ts
@@ -39,6 +39,14 @@ describe('WebSocketHandler', () => {
     expect(result.code).toContain('export class CustomNamespace');
   });
 
+  it('should not start with leading blank line when appended to empty code', () => {
+    const handler = new WebSocketHandler('');
+    const result = handler.addWebSocketNamespace('TestNamespace', '/test');
+
+    // Should start with \n (for separation) then directly @WebSocket, not \n\n
+    expect(result.code).not.toMatch(/^\n\n/);
+  });
+
   it('should append to existing code', () => {
     const existingCode = '// Existing code\n';
     const handler = new WebSocketHandler(existingCode);

--- a/test/commands/create.test.ts
+++ b/test/commands/create.test.ts
@@ -86,6 +86,19 @@ describe('Create command CLI arguments', () => {
     expect(noPrettierOption).toBeDefined();
   });
 
+  it('should have skip-install option', () => {
+    const create = new Create();
+    const command = create.command();
+
+    const options = command.options;
+
+    const skipInstallOption = options.find((opt) => opt.long === '--skip-install');
+
+    expect(skipInstallOption).toBeDefined();
+
+    expect(skipInstallOption?.description).toContain('Skip dependency installation');
+  });
+
   it('should parse all required options correctly', () => {
     const create = new Create();
     const command = create.command();
@@ -98,6 +111,7 @@ describe('Create command CLI arguments', () => {
       '--no-eslint',
       '--prettier',
       '--no-prettier',
+      '--skip-install',
     ];
 
     const commandOptions = command.options.map((opt) => opt.long);
@@ -276,5 +290,74 @@ describe('Create command package.json generation', () => {
     const packageJson = JSON.parse(packageJsonContent);
 
     expect(packageJson.module).toBe('src/index.ts');
+  });
+
+  it('should include dependencies in package.json when skipInstall is true', async () => {
+    const create = new Create();
+    const projectPath = tempDir;
+
+    (create as any).preference = {
+      projectName: 'TestProject',
+      adapter: 'hono',
+      logger: true,
+      eslint: true,
+      prettier: true,
+    };
+
+    await (create as any).createPackageJson(projectPath, true);
+
+    const packageJsonPath = join(projectPath, 'package.json');
+    const packageJsonContent = await Bun.file(packageJsonPath).text();
+    const packageJson = JSON.parse(packageJsonContent);
+
+    // Should have dependencies
+    expect(packageJson.dependencies).toBeDefined();
+    expect(packageJson.dependencies['@asenajs/asena']).toBe('latest');
+    expect(packageJson.dependencies['@asenajs/hono-adapter']).toBe('latest');
+    expect(packageJson.dependencies['@asenajs/asena-logger']).toBe('latest');
+
+    // Should have devDependencies
+    expect(packageJson.devDependencies).toBeDefined();
+    expect(packageJson.devDependencies['@types/bun']).toBe('latest');
+    expect(packageJson.devDependencies['typescript']).toBe('latest');
+    expect(packageJson.devDependencies['@asenajs/asena-cli']).toBe('latest');
+    expect(packageJson.devDependencies['eslint']).toBe('latest');
+    expect(packageJson.devDependencies['prettier']).toBe('latest');
+  });
+
+  it('should not include dependencies when skipInstall is false', async () => {
+    const create = new Create();
+    const projectPath = tempDir;
+
+    await (create as any).createPackageJson(projectPath, false);
+
+    const packageJsonPath = join(projectPath, 'package.json');
+    const packageJsonContent = await Bun.file(packageJsonPath).text();
+    const packageJson = JSON.parse(packageJsonContent);
+
+    expect(packageJson.dependencies).toBeUndefined();
+    expect(packageJson.devDependencies).toBeUndefined();
+  });
+
+  it('should include ergenecore adapter when skipInstall is true with ergenecore', async () => {
+    const create = new Create();
+    const projectPath = tempDir;
+
+    (create as any).preference = {
+      projectName: 'TestProject',
+      adapter: 'ergenecore',
+      logger: false,
+      eslint: false,
+      prettier: false,
+    };
+
+    await (create as any).createPackageJson(projectPath, true);
+
+    const packageJsonPath = join(projectPath, 'package.json');
+    const packageJsonContent = await Bun.file(packageJsonPath).text();
+    const packageJson = JSON.parse(packageJsonContent);
+
+    expect(packageJson.dependencies['@asenajs/ergenecore']).toBe('latest');
+    expect(packageJson.dependencies['@asenajs/asena-logger']).toBeUndefined();
   });
 });

--- a/test/fixtures/sample-app/bun.lock
+++ b/test/fixtures/sample-app/bun.lock
@@ -1,0 +1,28 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "sample-app-test-fixture",
+      "dependencies": {
+        "@asenajs/asena": "^0.7.0",
+        "@asenajs/hono-adapter": "^1.2.0",
+      },
+    },
+  },
+  "packages": {
+    "@asenajs/asena": ["@asenajs/asena@0.7.0", "", { "dependencies": { "reflect-metadata": "^0.2.2" } }, "sha512-qU+NkkorV8rx++AT1snv5WG7+BVaiwzM8541pbENRwYx1nxqp8BgYEv01LHkJFNR28VrEqAo1lhvOuEhNe4oYQ=="],
+
+    "@asenajs/hono-adapter": ["@asenajs/hono-adapter@1.5.0", "", { "dependencies": { "@hono/zod-validator": "^0.4.3", "hono": "^4.12.9", "zod": "^4.3.6" }, "peerDependencies": { "@asenajs/asena": "^0.7.0", "typescript": "^5.8.2" } }, "sha512-9+SJV19VisYcpsCfn88lEHaYo7m9Gk/9G/w8bq10ppAJWGgBVznXiThliSN1lpKl6Xggue5WCyWvC6oIQz2eFQ=="],
+
+    "@hono/zod-validator": ["@hono/zod-validator@0.4.3", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.19.1" } }, "sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ=="],
+
+    "hono": ["hono@4.12.11", "", {}, "sha512-r4xbIa3mGGGoH9nN4A14DOg2wx7y2oQyJEb5O57C/xzETG/qx4c7CVDQ5WMeKHZ7ORk2W0hZ/sQKXTav3cmYBA=="],
+
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+  }
+}

--- a/test/fixtures/sample-app/package.json
+++ b/test/fixtures/sample-app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Test fixture for @asenajs/asena-cli component detection integration tests",
   "dependencies": {
-    "@asenajs/asena": "^0.4.0",
+    "@asenajs/asena": "^0.7.0",
     "@asenajs/hono-adapter": "^1.2.0"
   }
 }

--- a/test/fixtures/sample-app/src/controllers/TestController.ts
+++ b/test/fixtures/sample-app/src/controllers/TestController.ts
@@ -1,5 +1,5 @@
-import { Controller } from '@asenajs/asena/server';
-import { Get } from '@asenajs/asena/web';
+import { Controller } from '@asenajs/asena/decorators';
+import { Get } from '@asenajs/asena/decorators/http';
 import type { Context } from '@asenajs/hono-adapter';
 
 @Controller({ path: '/test' })

--- a/test/fixtures/sample-app/src/services/TestService.ts
+++ b/test/fixtures/sample-app/src/services/TestService.ts
@@ -1,4 +1,4 @@
-import { Service } from '@asenajs/asena/server';
+import { Service } from '@asenajs/asena/decorators';
 
 @Service('TestService')
 export class TestService {

--- a/test/helpers/RegexHelper.test.ts
+++ b/test/helpers/RegexHelper.test.ts
@@ -175,7 +175,7 @@ console.log('Done');
     it('should extract import lines', () => {
       const code = `
 import { AsenaServer } from '@asenajs/asena';
-import { Controller } from '@asenajs/asena/server';
+import { Controller } from '@asenajs/asena/decorators';
 import type { Context } from 'hono';
 
 const x = 1;

--- a/test/helpers/adapterConfigHelper.test.ts
+++ b/test/helpers/adapterConfigHelper.test.ts
@@ -8,6 +8,7 @@ import {
   isAdapterConfigExists,
   resolveSuffix,
 } from '../../lib/helpers';
+import { CONFIG_SCHEMA } from '../../lib/constants/configSchema';
 
 describe('adapterConfigHelper', () => {
   const TEST_DIR = path.join(import.meta.dir, '__test_adapter_config__');
@@ -66,6 +67,52 @@ describe('adapterConfigHelper', () => {
       // Check if it's pretty-printed (has newlines and spaces)
       expect(content).toContain('\n');
       expect(content).toContain('  ');
+
+      process.chdir(ORIGINAL_CWD);
+    });
+
+    it('should add $schema reference to config.json', async () => {
+      process.chdir(TEST_DIR);
+      await rm(path.join(TEST_DIR, '.asena'), { recursive: true, force: true });
+
+      await writeAdapterConfig({ adapter: 'hono' });
+
+      const content = await Bun.file(path.join(TEST_DIR, '.asena/config.json')).json();
+
+      expect(content.$schema).toBe('./config.schema.json');
+
+      process.chdir(ORIGINAL_CWD);
+    });
+
+    it('should write config.schema.json alongside config.json', async () => {
+      process.chdir(TEST_DIR);
+      await rm(path.join(TEST_DIR, '.asena'), { recursive: true, force: true });
+
+      await writeAdapterConfig({ adapter: 'hono' });
+
+      const schemaPath = path.join(TEST_DIR, '.asena/config.schema.json');
+      const exists = await Bun.file(schemaPath).exists();
+
+      expect(exists).toBe(true);
+
+      const schema = await Bun.file(schemaPath).json();
+
+      expect(schema.$schema).toBe('http://json-schema.org/draft-07/schema#');
+      expect(schema.title).toBe('Asena CLI Configuration');
+      expect(schema.properties.adapter.enum).toEqual(['hono', 'ergenecore']);
+
+      process.chdir(ORIGINAL_CWD);
+    });
+
+    it('should write schema matching CONFIG_SCHEMA constant', async () => {
+      process.chdir(TEST_DIR);
+      await rm(path.join(TEST_DIR, '.asena'), { recursive: true, force: true });
+
+      await writeAdapterConfig({ adapter: 'ergenecore' });
+
+      const schema = await Bun.file(path.join(TEST_DIR, '.asena/config.schema.json')).json();
+
+      expect(schema).toEqual(CONFIG_SCHEMA);
 
       process.chdir(ORIGINAL_CWD);
     });

--- a/test/helpers/adapterImportHelper.test.ts
+++ b/test/helpers/adapterImportHelper.test.ts
@@ -32,9 +32,9 @@ describe('adapterImportHelper', () => {
     it('should return Hono controller imports for hono adapter', () => {
       const imports = getControllerImports('hono');
 
-      expect(imports['@asenajs/asena/server']).toContain('Controller');
+      expect(imports['@asenajs/asena/decorators']).toContain('Controller');
 
-      expect(imports['@asenajs/asena/web']).toContain('Get');
+      expect(imports['@asenajs/asena/decorators/http']).toContain('Get');
 
       expect(imports['@asenajs/hono-adapter']).toContain('type Context');
     });
@@ -42,9 +42,9 @@ describe('adapterImportHelper', () => {
     it('should return Ergenecore controller imports for ergenecore adapter', () => {
       const imports = getControllerImports('ergenecore');
 
-      expect(imports['@asenajs/asena/server']).toContain('Controller');
+      expect(imports['@asenajs/asena/decorators']).toContain('Controller');
 
-      expect(imports['@asenajs/asena/web']).toContain('Get');
+      expect(imports['@asenajs/asena/decorators/http']).toContain('Get');
 
       expect(imports['@asenajs/ergenecore']).toContain('type Context');
     });
@@ -54,7 +54,7 @@ describe('adapterImportHelper', () => {
     it('should return Hono middleware imports for hono adapter', () => {
       const imports = getMiddlewareImports('hono');
 
-      expect(imports['@asenajs/asena/server']).toContain('Middleware');
+      expect(imports['@asenajs/asena/decorators']).toContain('Middleware');
 
       expect(imports['@asenajs/hono-adapter']).toContain('type Context');
 
@@ -64,7 +64,7 @@ describe('adapterImportHelper', () => {
     it('should return Ergenecore middleware imports for ergenecore adapter', () => {
       const imports = getMiddlewareImports('ergenecore');
 
-      expect(imports['@asenajs/asena/server']).toContain('Middleware');
+      expect(imports['@asenajs/asena/decorators']).toContain('Middleware');
 
       expect(imports['@asenajs/ergenecore']).toContain('type Context');
 
@@ -76,7 +76,7 @@ describe('adapterImportHelper', () => {
     it('should return Hono config imports for hono adapter', () => {
       const imports = getConfigImports('hono');
 
-      expect(imports['@asenajs/asena/server']).toContain('Config');
+      expect(imports['@asenajs/asena/decorators']).toContain('Config');
 
       expect(imports['@asenajs/hono-adapter']).toContain('ConfigService');
 
@@ -86,7 +86,7 @@ describe('adapterImportHelper', () => {
     it('should return Ergenecore config imports for ergenecore adapter', () => {
       const imports = getConfigImports('ergenecore');
 
-      expect(imports['@asenajs/asena/server']).toContain('Config');
+      expect(imports['@asenajs/asena/decorators']).toContain('Config');
 
       expect(imports['@asenajs/ergenecore']).toContain('ConfigService');
 
@@ -98,7 +98,7 @@ describe('adapterImportHelper', () => {
     it('should return adapter-agnostic WebSocket imports', () => {
       const imports = getWebSocketImports();
 
-      expect(imports['@asenajs/asena/server']).toContain('WebSocket');
+      expect(imports['@asenajs/asena/decorators']).toContain('WebSocket');
 
       expect(imports['@asenajs/asena/web-socket']).toContain('AsenaWebSocketService');
 


### PR DESCRIPTION
## Summary

- **Import path migration**: All generated code now uses `@asenajs/asena/decorators` and `@asenajs/asena/decorators/http` instead of the deprecated `@asenajs/asena/server` and `@asenajs/asena/web` paths, aligning with Asena v0.7.0 exports
- **Code generation quality**: Replaced tab indentation with 2-space indentation, enforced single quotes, and fixed spacing inconsistencies across all code generators (Controller, Middleware, Validator, WebSocket, ServerConfig)
- **`--skip-install` flag**: New option for `asena create` that writes dependencies to package.json without running `bun install` — useful for monorepos and offline workflows
- **`.gitignore` generation**: New projects now include a `.gitignore` with sensible defaults (node_modules, dist, .env, IDE files)
- **Config JSON Schema**: `.asena/config.json` now ships with a `config.schema.json` for IDE autocomplete and validation support
- **Create command improvements**: Uses current folder name as project name (was hardcoded "myApp"), adds `dev` and `dev:hot` scripts
- **Dependency updates**: `@asenajs/asena` ^0.6.0 → ^0.7.0, eslint, prettier, typescript-eslint bumped