### PR TITLE
feat: add include option and HTML import handling for FrontendController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @asenajs/asena-cli
 
+## 0.7.1
+
+### Patch Changes
+
+- ### Features
+  - **Include Option**: New `include` config property allows specifying files and directories to copy into the build output. Essential for `@FrontendController` HTML files whose import paths are static and break after bundling.
+  - **HTML Build Plugin**: Bun build plugin that marks `.html` imports as external and collects path mappings during build for post-build rewriting.
+  - **HTML Import Rewriting**: Post-build step that rewrites HTML import paths in bundled JavaScript files to point to correct relative locations.
+
+  ### Fixes
+  - **Entry Point**: Default production script now uses `dist/index.asena.js` instead of `dist/index.js`.
+
+  ### Tests
+  - Added comprehensive test suite for `copyIncludedAssets()`, `createHTMLPlugin()`, and `rewriteHTMLImports()` (622 lines).
+
 ## 0.7.0
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Asena CLI
 
-[![Version](https://img.shields.io/badge/version-0.7.0-blue.svg)](https://asena.sh)
+[![Version](https://img.shields.io/badge/version-0.7.1-blue.svg)](https://asena.sh)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Bun Version](https://img.shields.io/badge/Bun-1.3.11%2B-blueviolet)](https://bun.sh)
 

--- a/README.md
+++ b/README.md
@@ -162,15 +162,15 @@ The Init command helps set up project configuration with default settings(no nee
 Customization via `asena.config.ts`:
 
 ```typescript
-import { defineConfig } from '@asenajs/asena'
+import { defineConfig } from '@asenajs/asena-cli'
 
 export default defineConfig({
     sourceFolder: 'src', // folder where the project files are located
     rootFile: 'src/index.ts', // entry file of the project
+    include: ['public'], // files/directories to copy to output (required for @FrontendController)
     buildOptions: { // build options. For more details, visit https://bun.sh/docs/bundler
         outdir: 'dist',
         sourcemap: 'linked',
-        target: 'bun',
         minify: {
             whitespace: true,
             syntax: true,
@@ -179,6 +179,8 @@ export default defineConfig({
     },
 });
 ```
+
+> **Note:** When using `@FrontendController`, the `include` option must list directories containing your HTML files. The CLI automatically rewrites HTML import paths during build so they resolve correctly from the output directory. Do **not** add `*.html` to `buildOptions.external`.
 
 ## 📂 Project Structure
 

--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
     },
   },
   "packages": {
-    "@asenajs/asena": ["@asenajs/asena@0.7.0", "", { "dependencies": { "reflect-metadata": "^0.2.2" } }, "sha512-qU+NkkorV8rx++AT1snv5WG7+BVaiwzM8541pbENRwYx1nxqp8BgYEv01LHkJFNR28VrEqAo1lhvOuEhNe4oYQ=="],
+    "@asenajs/asena": ["@asenajs/asena@0.7.1", "", { "dependencies": { "reflect-metadata": "^0.2.2" } }, "sha512-bSk+6iDZSup4PctgsaeS9YJuRG7C7sbt/xkqtt1gpAozcfWmRSOTzhS0WV95hNen11xowxA064FeO9QwzZWMVA=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
@@ -136,37 +136,37 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
 
     "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
 
-    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.58.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.58.0", "@typescript-eslint/type-utils": "8.58.0", "@typescript-eslint/utils": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.58.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg=="],
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.58.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.58.1", "@typescript-eslint/type-utils": "8.58.1", "@typescript-eslint/utils": "8.58.1", "@typescript-eslint/visitor-keys": "8.58.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.58.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ=="],
 
-    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.58.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.58.0", "@typescript-eslint/types": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA=="],
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.58.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.58.1", "@typescript-eslint/types": "8.58.1", "@typescript-eslint/typescript-estree": "8.58.1", "@typescript-eslint/visitor-keys": "8.58.1", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw=="],
 
-    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.58.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.58.0", "@typescript-eslint/types": "^8.58.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg=="],
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.58.1", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.58.1", "@typescript-eslint/types": "^8.58.1", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g=="],
 
-    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0" } }, "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ=="],
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.58.1", "", { "dependencies": { "@typescript-eslint/types": "8.58.1", "@typescript-eslint/visitor-keys": "8.58.1" } }, "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w=="],
 
-    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.58.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A=="],
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.58.1", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw=="],
 
-    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0", "@typescript-eslint/utils": "8.58.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg=="],
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.58.1", "", { "dependencies": { "@typescript-eslint/types": "8.58.1", "@typescript-eslint/typescript-estree": "8.58.1", "@typescript-eslint/utils": "8.58.1", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w=="],
 
-    "@typescript-eslint/types": ["@typescript-eslint/types@8.58.0", "", {}, "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww=="],
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.58.1", "", {}, "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw=="],
 
-    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.58.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.58.0", "@typescript-eslint/tsconfig-utils": "8.58.0", "@typescript-eslint/types": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA=="],
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.58.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.58.1", "@typescript-eslint/tsconfig-utils": "8.58.1", "@typescript-eslint/types": "8.58.1", "@typescript-eslint/visitor-keys": "8.58.1", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg=="],
 
-    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.58.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.58.0", "@typescript-eslint/types": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA=="],
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.58.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.58.1", "@typescript-eslint/types": "8.58.1", "@typescript-eslint/typescript-estree": "8.58.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ=="],
 
-    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ=="],
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.1", "", { "dependencies": { "@typescript-eslint/types": "8.58.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -188,11 +188,11 @@
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
-    "brace-expansion": ["brace-expansion@1.1.13", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w=="],
+    "brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -392,7 +392,7 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
-    "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
+    "prettier": ["prettier@3.8.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
@@ -446,7 +446,7 @@
 
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
 
-    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -458,9 +458,9 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "typescript-eslint": ["typescript-eslint@8.58.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.58.0", "@typescript-eslint/parser": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0", "@typescript-eslint/utils": "8.58.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA=="],
+    "typescript-eslint": ["typescript-eslint@8.58.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.58.1", "@typescript-eslint/parser": "8.58.1", "@typescript-eslint/typescript-estree": "8.58.1", "@typescript-eslint/utils": "8.58.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg=="],
 
-    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 

--- a/lib/codeBuilder/ConfigHandler.ts
+++ b/lib/codeBuilder/ConfigHandler.ts
@@ -31,6 +31,10 @@ export class ConfigHandler {
     return this._configFile.buildOptions?.outdir ? this._configFile.buildOptions?.outdir : './out';
   }
 
+  public get include(): string[] {
+    return this._configFile.include || [];
+  }
+
   private readConfigFile = async () => {
     const folderPath = path.normalize(path.join(process.cwd()));
     const files: string[] = getAllFiles(folderPath);

--- a/lib/commands/Build.ts
+++ b/lib/commands/Build.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { type BuildConfig, write } from 'bun';
+import { type BuildConfig, type BunPlugin, write } from 'bun';
 import { Command } from 'commander';
 import { AsenaServerHandler, ConfigHandler, ImportHandler } from '../codeBuilder';
 import {
@@ -44,6 +44,8 @@ export class Build implements BaseCommand {
       await write(this._buildFilePath, buildCode);
 
       await this.executeBuild();
+
+      await this.copyIncludedAssets();
 
       this.removeAsenaEntryFile();
 
@@ -143,11 +145,14 @@ export class Build implements BaseCommand {
  * ╚═══════════════════════════════════════╝
  */`;
 
+    const { plugin: htmlPlugin, htmlImports } = this.createHTMLPlugin();
+
     const defaultBuildConfig: BuildConfig = {
       entrypoints: [this._buildFilePath],
       outdir: './out',
       target: 'bun',
       footer: asenaFooter,
+      plugins: [htmlPlugin],
     };
 
     const finalBuildConfig: BuildConfig = this.configFile.buildOptions
@@ -156,11 +161,132 @@ export class Build implements BaseCommand {
           entrypoints: [this._buildFilePath],
           target: 'bun',
           footer: asenaFooter,
+          plugins: [htmlPlugin],
         }
       : defaultBuildConfig;
 
-    return await Bun.build(finalBuildConfig);
+    const result = await Bun.build(finalBuildConfig);
+
+    if (result.success && htmlImports.size > 0) {
+      const outdir = this.configFile.buildOptions?.outdir || './out';
+
+      this.rewriteHTMLImports(outdir, htmlImports);
+    }
+
+    return result;
   };
+
+  /**
+   * Creates a Bun build plugin that marks .html imports as external and collects
+   * path mappings for post-build rewriting.
+   *
+   * Bun's bundler preserves the original import specifier for external modules,
+   * so path rewrites from onResolve are NOT applied to the output.
+   * The collected htmlImports map is used by rewriteHTMLImports() after the build.
+   */
+  private createHTMLPlugin(): { plugin: BunPlugin; htmlImports: Map<string, string> } {
+    const htmlImports = new Map<string, string>();
+
+    const plugin: BunPlugin = {
+      name: 'asena-html-resolver',
+      setup(build) {
+        build.onResolve({ filter: /\.html$/ }, (args) => {
+          const absolutePath = path.resolve(path.dirname(args.importer), args.path);
+
+          if (!fs.existsSync(absolutePath)) {
+            throw new Error(`HTML file not found: ${absolutePath} (imported from ${args.importer})`);
+          }
+
+          const relativePath = path.relative(process.cwd(), absolutePath).replace(/\\/g, '/');
+          const rewrittenPath = './' + relativePath;
+
+          htmlImports.set(args.path, rewrittenPath);
+
+          return {
+            path: rewrittenPath,
+            external: true,
+          };
+        });
+      },
+    };
+
+    return { plugin, htmlImports };
+  }
+
+  /**
+   * Rewrites HTML import paths in the build output files.
+   * Bun preserves original import specifiers for external modules,
+   * so we need to fix them post-build to match the copied file locations.
+   */
+  private rewriteHTMLImports(outdir: string, htmlImports: Map<string, string>) {
+    const outputFiles = fs.readdirSync(outdir).filter((f) => f.endsWith('.js'));
+
+    for (const file of outputFiles) {
+      const filePath = path.join(outdir, file);
+      let content = fs.readFileSync(filePath, 'utf-8');
+      let modified = false;
+
+      for (const [originalPath, rewrittenPath] of htmlImports) {
+        if (content.includes(`"${originalPath}"`)) {
+          content = content.replaceAll(`"${originalPath}"`, `"${rewrittenPath}"`);
+          modified = true;
+        }
+      }
+
+      if (modified) {
+        fs.writeFileSync(filePath, content);
+      }
+    }
+  }
+
+  /**
+   * Copies files and directories listed in the `include` config to the output directory.
+   * Directories are copied recursively, preserving their structure.
+   */
+  private async copyIncludedAssets() {
+    const include = this.configFile.include;
+
+    if (!include || include.length === 0) {
+      return;
+    }
+
+    const outdir = this.configFile.buildOptions?.outdir || './out';
+
+    for (const entry of include) {
+      const srcPath = path.resolve(process.cwd(), entry);
+      const destPath = path.join(outdir, entry);
+
+      if (!fs.existsSync(srcPath)) {
+        console.warn(`\x1b[33m[include]\x1b[0m Skipping "${entry}" — path not found`);
+
+        continue;
+      }
+
+      const stat = fs.statSync(srcPath);
+
+      if (stat.isDirectory()) {
+        this.copyDirRecursive(srcPath, destPath);
+      } else {
+        fs.mkdirSync(path.dirname(destPath), { recursive: true });
+        fs.copyFileSync(srcPath, destPath);
+      }
+    }
+  }
+
+  private copyDirRecursive(src: string, dest: string) {
+    fs.mkdirSync(dest, { recursive: true });
+
+    for (const entry of fs.readdirSync(src)) {
+      const srcEntry = path.join(src, entry);
+      const destEntry = path.join(dest, entry);
+
+      if (fs.statSync(srcEntry).isDirectory()) {
+        this.copyDirRecursive(srcEntry, destEntry);
+      } else {
+        fs.copyFileSync(srcEntry, destEntry);
+      }
+    }
+  }
 
   private createBuildFilePath(): string {
     return `${path.dirname(this.configFile.rootFile)}/${changeFileExtensionToAsenaJs(simplifyPath(this.configFile.rootFile))}`;

--- a/lib/commands/Commands.ts
+++ b/lib/commands/Commands.ts
@@ -11,7 +11,7 @@ export class Commands {
   public constructor() {
     this.program.name('asena');
 
-    this.program.version('0.7.0');
+    this.program.version('0.7.1');
 
     this.program.addCommand(new Create().command());
 

--- a/lib/commands/Create.ts
+++ b/lib/commands/Create.ts
@@ -172,7 +172,7 @@ export class Create implements BaseCommand {
       'dev:hot': 'bun run --hot src/index.ts',
       start: 'bun src/index.ts',
       build: 'asena build',
-      'start:prod': 'bun run dist/index.js',
+      'start:prod': 'bun run dist/index.asena.js',
     };
 
     // Add ESLint scripts if enabled

--- a/lib/constants/init.ts
+++ b/lib/constants/init.ts
@@ -2,6 +2,7 @@ export const INITIAL_ASENA_CONFIG_TS = `import {defineConfig} from "@asenajs/ase
 export default defineConfig({
   sourceFolder: 'src',
   rootFile: 'src/index.ts',
+  // include: ['public'], // Directories/files to copy into outdir during build
   buildOptions: {
     outdir: 'dist',
     minify: {

--- a/lib/types/asenaConfig.ts
+++ b/lib/types/asenaConfig.ts
@@ -90,4 +90,16 @@ export interface AsenaConfig {
    * @see {@link BuildOptions}
    */
   buildOptions?: BuildOptions;
+
+  /**
+   * Files and directories to copy into the output directory during build.
+   *
+   * Useful for including static assets (HTML pages, CSS, images) that are
+   * referenced at runtime but not bundled by the bundler.
+   *
+   * Paths are relative to the project root. Directories are copied recursively.
+   *
+   * @example ['public', 'static', 'templates/email.html']
+   */
+  include?: string[];
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asenajs/asena-cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": "LibirSoft",
   "license": "MIT",
   "bin": {
@@ -33,7 +33,7 @@
     "url": "https://github.com/AsenaJs/Asena-cli"
   },
   "dependencies": {
-    "@asenajs/asena": "^0.7.0",
+    "@asenajs/asena": "^0.7.1",
     "@changesets/cli": "^2.30.0",
     "commander": "^12.1.0",
     "inquirer": "^12.11.1",
@@ -44,13 +44,13 @@
   "devDependencies": {
     "@types/bun": "latest",
     "@types/yargs": "^17.0.35",
-    "@typescript-eslint/eslint-plugin": "^8.58.0",
-    "@typescript-eslint/parser": "^8.58.0",
+    "@typescript-eslint/eslint-plugin": "^8.58.1",
+    "@typescript-eslint/parser": "^8.58.1",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^9.1.2",
-    "prettier": "^3.8.1",
+    "prettier": "^3.8.2",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.58.0"
+    "typescript-eslint": "^8.58.1"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/test/commands/build.test.ts
+++ b/test/commands/build.test.ts
@@ -1,0 +1,622 @@
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import fs from 'fs';
+import path from 'path';
+import { Build } from '../../lib/commands/Build';
+
+const TMP_DIR = path.join(import.meta.dir, '../.tmp-build-test');
+
+function setupTmpDir() {
+  fs.mkdirSync(TMP_DIR, { recursive: true });
+}
+
+function cleanupTmpDir() {
+  if (fs.existsSync(TMP_DIR)) {
+    fs.rmSync(TMP_DIR, { recursive: true, force: true });
+  }
+}
+
+describe('Build', () => {
+  describe('copyIncludedAssets', () => {
+    let build: Build;
+
+    beforeEach(() => {
+      build = new Build();
+      setupTmpDir();
+    });
+
+    afterEach(() => {
+      cleanupTmpDir();
+    });
+
+    it('should copy a directory recursively to outdir', async () => {
+      // Create source structure: public/css/style.css, public/index.html
+      const publicDir = path.join(TMP_DIR, 'public');
+      const cssDir = path.join(publicDir, 'css');
+
+      fs.mkdirSync(cssDir, { recursive: true });
+      fs.writeFileSync(path.join(publicDir, 'index.html'), '<html>test</html>');
+      fs.writeFileSync(path.join(cssDir, 'style.css'), 'body { color: red; }');
+
+      const outdir = path.join(TMP_DIR, 'dist');
+
+      fs.mkdirSync(outdir, { recursive: true });
+
+      // Access private method via bracket notation
+      build['configFile'] = {
+        rootFile: 'src/index.ts',
+        sourceFolder: 'src',
+        include: ['public'],
+        buildOptions: { outdir },
+      };
+
+      // Save and restore cwd since copyIncludedAssets uses process.cwd()
+      const originalCwd = process.cwd();
+
+      process.chdir(TMP_DIR);
+
+      try {
+        await build['copyIncludedAssets']();
+      } finally {
+        process.chdir(originalCwd);
+      }
+
+      // Verify files were copied
+      expect(fs.existsSync(path.join(outdir, 'public', 'index.html'))).toBe(true);
+      expect(fs.existsSync(path.join(outdir, 'public', 'css', 'style.css'))).toBe(true);
+
+      // Verify content
+      const htmlContent = fs.readFileSync(path.join(outdir, 'public', 'index.html'), 'utf-8');
+
+      expect(htmlContent).toBe('<html>test</html>');
+
+      const cssContent = fs.readFileSync(path.join(outdir, 'public', 'css', 'style.css'), 'utf-8');
+
+      expect(cssContent).toBe('body { color: red; }');
+    });
+
+    it('should copy a single file to outdir', async () => {
+      fs.writeFileSync(path.join(TMP_DIR, 'config.json'), '{"key": "value"}');
+
+      const outdir = path.join(TMP_DIR, 'dist');
+
+      fs.mkdirSync(outdir, { recursive: true });
+
+      build['configFile'] = {
+        rootFile: 'src/index.ts',
+        sourceFolder: 'src',
+        include: ['config.json'],
+        buildOptions: { outdir },
+      };
+
+      const originalCwd = process.cwd();
+
+      process.chdir(TMP_DIR);
+
+      try {
+        await build['copyIncludedAssets']();
+      } finally {
+        process.chdir(originalCwd);
+      }
+
+      expect(fs.existsSync(path.join(outdir, 'config.json'))).toBe(true);
+
+      const content = fs.readFileSync(path.join(outdir, 'config.json'), 'utf-8');
+
+      expect(content).toBe('{"key": "value"}');
+    });
+
+    it('should skip non-existent paths with a warning', async () => {
+      const outdir = path.join(TMP_DIR, 'dist');
+
+      fs.mkdirSync(outdir, { recursive: true });
+
+      build['configFile'] = {
+        rootFile: 'src/index.ts',
+        sourceFolder: 'src',
+        include: ['nonexistent-dir'],
+        buildOptions: { outdir },
+      };
+
+      const originalCwd = process.cwd();
+
+      process.chdir(TMP_DIR);
+
+      try {
+        // Should not throw
+        await build['copyIncludedAssets']();
+      } finally {
+        process.chdir(originalCwd);
+      }
+
+      // outdir should still exist but be empty (no crash)
+      expect(fs.existsSync(outdir)).toBe(true);
+    });
+
+    it('should do nothing when include is empty', async () => {
+      const outdir = path.join(TMP_DIR, 'dist');
+
+      fs.mkdirSync(outdir, { recursive: true });
+
+      build['configFile'] = {
+        rootFile: 'src/index.ts',
+        sourceFolder: 'src',
+        include: [],
+        buildOptions: { outdir },
+      };
+
+      // Should not throw
+      await build['copyIncludedAssets']();
+    });
+
+    it('should do nothing when include is undefined', async () => {
+      build['configFile'] = {
+        rootFile: 'src/index.ts',
+        sourceFolder: 'src',
+        buildOptions: { outdir: path.join(TMP_DIR, 'dist') },
+      };
+
+      // Should not throw
+      await build['copyIncludedAssets']();
+    });
+  });
+
+  describe('createHTMLPlugin', () => {
+    it('should return a BunPlugin with correct name and htmlImports map', () => {
+      const build = new Build();
+      const { plugin, htmlImports } = build['createHTMLPlugin']();
+
+      expect(plugin.name).toBe('asena-html-resolver');
+      expect(plugin.setup).toBeFunction();
+      expect(htmlImports).toBeInstanceOf(Map);
+      expect(htmlImports.size).toBe(0);
+    });
+
+    it('should collect html imports when onResolve is triggered', () => {
+      const build = new Build();
+      const { plugin, htmlImports } = build['createHTMLPlugin']();
+
+      // Create a real HTML file so the plugin can verify it exists
+      const htmlDir = path.join(TMP_DIR, 'public');
+
+      fs.mkdirSync(htmlDir, { recursive: true });
+      fs.writeFileSync(path.join(htmlDir, 'test.html'), '<html></html>');
+
+      // Simulate what Bun's build.onResolve does
+      let resolveCallback: (args: { path: string; importer: string }) => { path: string; external: boolean };
+
+      const fakeBuild = {
+        onResolve: (_filter: unknown, cb: typeof resolveCallback) => {
+          resolveCallback = cb;
+        },
+      };
+
+      plugin.setup(fakeBuild as never);
+
+      const originalCwd = process.cwd();
+
+      process.chdir(TMP_DIR);
+
+      try {
+        // ../../public/test.html from src/controllers/ resolves to public/test.html
+        const result = resolveCallback!({
+          path: '../../public/test.html',
+          importer: path.join(TMP_DIR, 'src', 'controllers', 'Frontend.ts'),
+        });
+
+        expect(result.external).toBe(true);
+        expect(result.path).toBe('./public/test.html');
+        expect(htmlImports.size).toBe(1);
+        expect(htmlImports.get('../../public/test.html')).toBe('./public/test.html');
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it('should throw when HTML file does not exist', () => {
+      const build = new Build();
+      const { plugin } = build['createHTMLPlugin']();
+
+      let resolveCallback: (args: { path: string; importer: string }) => { path: string; external: boolean };
+
+      const fakeBuild = {
+        onResolve: (_filter: unknown, cb: typeof resolveCallback) => {
+          resolveCallback = cb;
+        },
+      };
+
+      plugin.setup(fakeBuild as never);
+
+      expect(() =>
+        resolveCallback!({
+          path: './nonexistent.html',
+          importer: path.join(TMP_DIR, 'src', 'index.ts'),
+        }),
+      ).toThrow('HTML file not found');
+    });
+
+    it('should handle deeply nested HTML imports', () => {
+      const build = new Build();
+      const { plugin, htmlImports } = build['createHTMLPlugin']();
+
+      const htmlDir = path.join(TMP_DIR, 'src', 'frontend', 'pages');
+
+      fs.mkdirSync(htmlDir, { recursive: true });
+      fs.writeFileSync(path.join(htmlDir, 'dashboard.html'), '<html></html>');
+
+      let resolveCallback: (args: { path: string; importer: string }) => { path: string; external: boolean };
+
+      const fakeBuild = {
+        onResolve: (_filter: unknown, cb: typeof resolveCallback) => {
+          resolveCallback = cb;
+        },
+      };
+
+      plugin.setup(fakeBuild as never);
+
+      const originalCwd = process.cwd();
+
+      process.chdir(TMP_DIR);
+
+      try {
+        const result = resolveCallback!({
+          path: '../../frontend/pages/dashboard.html',
+          importer: path.join(TMP_DIR, 'src', 'controllers', 'sub', 'Frontend.ts'),
+        });
+
+        expect(result.path).toBe('./src/frontend/pages/dashboard.html');
+        expect(htmlImports.get('../../frontend/pages/dashboard.html')).toBe('./src/frontend/pages/dashboard.html');
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it('should handle multiple HTML imports from different source files', () => {
+      const build = new Build();
+      const { plugin, htmlImports } = build['createHTMLPlugin']();
+
+      const publicDir = path.join(TMP_DIR, 'public');
+      const pagesDir = path.join(TMP_DIR, 'src', 'pages');
+
+      fs.mkdirSync(publicDir, { recursive: true });
+      fs.mkdirSync(pagesDir, { recursive: true });
+      fs.writeFileSync(path.join(publicDir, 'home.html'), '<html>home</html>');
+      fs.writeFileSync(path.join(pagesDir, 'about.html'), '<html>about</html>');
+
+      let resolveCallback: (args: { path: string; importer: string }) => { path: string; external: boolean };
+
+      const fakeBuild = {
+        onResolve: (_filter: unknown, cb: typeof resolveCallback) => {
+          resolveCallback = cb;
+        },
+      };
+
+      plugin.setup(fakeBuild as never);
+
+      const originalCwd = process.cwd();
+
+      process.chdir(TMP_DIR);
+
+      try {
+        resolveCallback!({
+          path: '../../public/home.html',
+          importer: path.join(TMP_DIR, 'src', 'controllers', 'HomeController.ts'),
+        });
+
+        resolveCallback!({
+          path: '../pages/about.html',
+          importer: path.join(TMP_DIR, 'src', 'controllers', 'AboutController.ts'),
+        });
+
+        expect(htmlImports.size).toBe(2);
+        expect(htmlImports.get('../../public/home.html')).toBe('./public/home.html');
+        expect(htmlImports.get('../pages/about.html')).toBe('./src/pages/about.html');
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+  });
+
+  describe('rewriteHTMLImports', () => {
+    let build: Build;
+
+    beforeEach(() => {
+      build = new Build();
+      setupTmpDir();
+    });
+
+    afterEach(() => {
+      cleanupTmpDir();
+    });
+
+    it('should rewrite HTML import paths in JS output files', () => {
+      const outdir = path.join(TMP_DIR, 'dist');
+
+      fs.mkdirSync(outdir, { recursive: true });
+      fs.writeFileSync(path.join(outdir, 'index.asena.js'), 'function load(){return import("../../public/test.html")}');
+
+      const htmlImports = new Map([['../../public/test.html', './public/test.html']]);
+
+      build['rewriteHTMLImports'](outdir, htmlImports);
+
+      const result = fs.readFileSync(path.join(outdir, 'index.asena.js'), 'utf-8');
+
+      expect(result).toBe('function load(){return import("./public/test.html")}');
+    });
+
+    it('should rewrite multiple different HTML imports', () => {
+      const outdir = path.join(TMP_DIR, 'dist');
+
+      fs.mkdirSync(outdir, { recursive: true });
+      fs.writeFileSync(
+        path.join(outdir, 'index.asena.js'),
+        [
+          'function home(){return import("../../public/home.html")}',
+          'function about(){return import("../pages/about.html")}',
+        ].join('\n'),
+      );
+
+      const htmlImports = new Map([
+        ['../../public/home.html', './public/home.html'],
+        ['../pages/about.html', './src/pages/about.html'],
+      ]);
+
+      build['rewriteHTMLImports'](outdir, htmlImports);
+
+      const result = fs.readFileSync(path.join(outdir, 'index.asena.js'), 'utf-8');
+
+      expect(result).toContain('import("./public/home.html")');
+      expect(result).toContain('import("./src/pages/about.html")');
+      expect(result).not.toContain('../../public/home.html');
+      expect(result).not.toContain('../pages/about.html');
+    });
+
+    it('should rewrite all occurrences of the same import', () => {
+      const outdir = path.join(TMP_DIR, 'dist');
+
+      fs.mkdirSync(outdir, { recursive: true });
+      fs.writeFileSync(
+        path.join(outdir, 'index.asena.js'),
+        'import("../../public/a.html");import("../../public/a.html");import("../../public/a.html")',
+      );
+
+      const htmlImports = new Map([['../../public/a.html', './public/a.html']]);
+
+      build['rewriteHTMLImports'](outdir, htmlImports);
+
+      const result = fs.readFileSync(path.join(outdir, 'index.asena.js'), 'utf-8');
+
+      expect(result).toBe('import("./public/a.html");import("./public/a.html");import("./public/a.html")');
+    });
+
+    it('should not modify files without HTML imports', () => {
+      const outdir = path.join(TMP_DIR, 'dist');
+
+      fs.mkdirSync(outdir, { recursive: true });
+
+      const originalContent = 'const x = 1; export default x;';
+
+      fs.writeFileSync(path.join(outdir, 'index.asena.js'), originalContent);
+
+      const htmlImports = new Map([['../../public/test.html', './public/test.html']]);
+
+      build['rewriteHTMLImports'](outdir, htmlImports);
+
+      const result = fs.readFileSync(path.join(outdir, 'index.asena.js'), 'utf-8');
+
+      expect(result).toBe(originalContent);
+    });
+
+    it('should only process .js files', () => {
+      const outdir = path.join(TMP_DIR, 'dist');
+
+      fs.mkdirSync(outdir, { recursive: true });
+
+      const jsContent = 'import("../../public/test.html")';
+      const cssContent = '/* import("../../public/test.html") */';
+
+      fs.writeFileSync(path.join(outdir, 'index.asena.js'), jsContent);
+      fs.writeFileSync(path.join(outdir, 'styles.css'), cssContent);
+
+      const htmlImports = new Map([['../../public/test.html', './public/test.html']]);
+
+      build['rewriteHTMLImports'](outdir, htmlImports);
+
+      // JS file should be rewritten
+      const jsResult = fs.readFileSync(path.join(outdir, 'index.asena.js'), 'utf-8');
+
+      expect(jsResult).toBe('import("./public/test.html")');
+
+      // CSS file should be untouched
+      const cssResult = fs.readFileSync(path.join(outdir, 'styles.css'), 'utf-8');
+
+      expect(cssResult).toBe(cssContent);
+    });
+
+    it('should handle empty outdir gracefully', () => {
+      const outdir = path.join(TMP_DIR, 'dist');
+
+      fs.mkdirSync(outdir, { recursive: true });
+
+      const htmlImports = new Map([['../../public/test.html', './public/test.html']]);
+
+      // Should not throw
+      build['rewriteHTMLImports'](outdir, htmlImports);
+    });
+
+    it('should handle empty htmlImports map', () => {
+      const outdir = path.join(TMP_DIR, 'dist');
+
+      fs.mkdirSync(outdir, { recursive: true });
+      fs.writeFileSync(path.join(outdir, 'index.asena.js'), 'const x = 1;');
+
+      const htmlImports = new Map<string, string>();
+
+      build['rewriteHTMLImports'](outdir, htmlImports);
+
+      const result = fs.readFileSync(path.join(outdir, 'index.asena.js'), 'utf-8');
+
+      expect(result).toBe('const x = 1;');
+    });
+
+    it('should preserve non-HTML import strings in the file', () => {
+      const outdir = path.join(TMP_DIR, 'dist');
+
+      fs.mkdirSync(outdir, { recursive: true });
+      fs.writeFileSync(
+        path.join(outdir, 'index.asena.js'),
+        'import("@asenajs/asena");import("../../public/test.html");import("hono");',
+      );
+
+      const htmlImports = new Map([['../../public/test.html', './public/test.html']]);
+
+      build['rewriteHTMLImports'](outdir, htmlImports);
+
+      const result = fs.readFileSync(path.join(outdir, 'index.asena.js'), 'utf-8');
+
+      expect(result).toBe('import("@asenajs/asena");import("./public/test.html");import("hono");');
+    });
+  });
+
+  describe('rewriteHTMLImports - security', () => {
+    let build: Build;
+
+    beforeEach(() => {
+      build = new Build();
+      setupTmpDir();
+    });
+
+    afterEach(() => {
+      cleanupTmpDir();
+    });
+
+    it('should only replace exact path matches within quotes', () => {
+      const outdir = path.join(TMP_DIR, 'dist');
+
+      fs.mkdirSync(outdir, { recursive: true });
+
+      // The string "../../public/test.html" appears in a different context (e.g., a log message)
+      fs.writeFileSync(
+        path.join(outdir, 'index.asena.js'),
+        ['const msg = "path is ../../public/test.html ok";', 'import("../../public/test.html");'].join('\n'),
+      );
+
+      const htmlImports = new Map([['../../public/test.html', './public/test.html']]);
+
+      build['rewriteHTMLImports'](outdir, htmlImports);
+
+      const result = fs.readFileSync(path.join(outdir, 'index.asena.js'), 'utf-8');
+
+      // The import should be rewritten
+      expect(result).toContain('import("./public/test.html")');
+      // The standalone string without quotes around only the path should NOT be affected
+      // because replaceAll targets `"../../public/test.html"` (with quotes)
+      expect(result).toContain('const msg = "path is ../../public/test.html ok"');
+    });
+
+    it('should not be affected by path traversal in import strings', () => {
+      const outdir = path.join(TMP_DIR, 'dist');
+
+      fs.mkdirSync(outdir, { recursive: true });
+
+      // A malicious-looking path that goes above the project root
+      fs.writeFileSync(path.join(outdir, 'index.asena.js'), 'import("../../../../etc/passwd.html")');
+
+      // Only rewrite known mappings - this path is NOT in the map
+      const htmlImports = new Map([['../../public/test.html', './public/test.html']]);
+
+      build['rewriteHTMLImports'](outdir, htmlImports);
+
+      const result = fs.readFileSync(path.join(outdir, 'index.asena.js'), 'utf-8');
+
+      // Unknown path should remain untouched
+      expect(result).toBe('import("../../../../etc/passwd.html")');
+    });
+
+    it('should not perform partial string replacements within longer paths', () => {
+      const outdir = path.join(TMP_DIR, 'dist');
+
+      fs.mkdirSync(outdir, { recursive: true });
+
+      fs.writeFileSync(path.join(outdir, 'index.asena.js'), 'import("../../public/test.html.bak")');
+
+      const htmlImports = new Map([['../../public/test.html', './public/test.html']]);
+
+      build['rewriteHTMLImports'](outdir, htmlImports);
+
+      const result = fs.readFileSync(path.join(outdir, 'index.asena.js'), 'utf-8');
+
+      // Should NOT match because "../../public/test.html.bak" != "../../public/test.html"
+      expect(result).toBe('import("../../public/test.html.bak")');
+    });
+
+    it('should not replace paths embedded in other strings', () => {
+      const outdir = path.join(TMP_DIR, 'dist');
+
+      fs.mkdirSync(outdir, { recursive: true });
+
+      fs.writeFileSync(path.join(outdir, 'index.asena.js'), 'const x = "prefix../../public/test.htmlsuffix";');
+
+      const htmlImports = new Map([['../../public/test.html', './public/test.html']]);
+
+      build['rewriteHTMLImports'](outdir, htmlImports);
+
+      const result = fs.readFileSync(path.join(outdir, 'index.asena.js'), 'utf-8');
+
+      // The replacement targets `"../../public/test.html"` with quotes, so this should NOT match
+      expect(result).toBe('const x = "prefix../../public/test.htmlsuffix";');
+    });
+
+    it('should handle paths with special regex characters safely', () => {
+      const outdir = path.join(TMP_DIR, 'dist');
+
+      fs.mkdirSync(outdir, { recursive: true });
+
+      fs.writeFileSync(path.join(outdir, 'index.asena.js'), 'import("../../public/test (1).html")');
+
+      const htmlImports = new Map([['../../public/test (1).html', './public/test (1).html']]);
+
+      build['rewriteHTMLImports'](outdir, htmlImports);
+
+      const result = fs.readFileSync(path.join(outdir, 'index.asena.js'), 'utf-8');
+
+      expect(result).toBe('import("./public/test (1).html")');
+    });
+
+    it('should handle paths with unicode characters', () => {
+      const outdir = path.join(TMP_DIR, 'dist');
+
+      fs.mkdirSync(outdir, { recursive: true });
+
+      fs.writeFileSync(path.join(outdir, 'index.asena.js'), 'import("../../public/sayfa-türkçe.html")');
+
+      const htmlImports = new Map([['../../public/sayfa-türkçe.html', './public/sayfa-türkçe.html']]);
+
+      build['rewriteHTMLImports'](outdir, htmlImports);
+
+      const result = fs.readFileSync(path.join(outdir, 'index.asena.js'), 'utf-8');
+
+      expect(result).toBe('import("./public/sayfa-türkçe.html")');
+    });
+
+    it('should handle multiple JS output files', () => {
+      const outdir = path.join(TMP_DIR, 'dist');
+
+      fs.mkdirSync(outdir, { recursive: true });
+      fs.writeFileSync(path.join(outdir, 'index.asena.js'), 'import("../../public/a.html")');
+      fs.writeFileSync(path.join(outdir, 'chunk-abc123.js'), 'import("../../public/b.html")');
+
+      const htmlImports = new Map([
+        ['../../public/a.html', './public/a.html'],
+        ['../../public/b.html', './public/b.html'],
+      ]);
+
+      build['rewriteHTMLImports'](outdir, htmlImports);
+
+      const result1 = fs.readFileSync(path.join(outdir, 'index.asena.js'), 'utf-8');
+      const result2 = fs.readFileSync(path.join(outdir, 'chunk-abc123.js'), 'utf-8');
+
+      expect(result1).toBe('import("./public/a.html")');
+      expect(result2).toBe('import("./public/b.html")');
+    });
+  });
+});

--- a/test/commands/create.test.ts
+++ b/test/commands/create.test.ts
@@ -153,7 +153,7 @@ describe('Create command package.json generation', () => {
     expect(packageJson.scripts).toBeDefined();
     expect(packageJson.scripts.start).toBe('bun src/index.ts');
     expect(packageJson.scripts.build).toBe('asena build');
-    expect(packageJson.scripts['start:prod']).toBe('bun run dist/index.js');
+    expect(packageJson.scripts['start:prod']).toBe('bun run dist/index.asena.js');
   });
 
   it('should include eslint scripts when eslint is enabled', async () => {
@@ -262,7 +262,7 @@ describe('Create command package.json generation', () => {
     // But basic scripts should still exist
     expect(packageJson.scripts.start).toBe('bun src/index.ts');
     expect(packageJson.scripts.build).toBe('asena build');
-    expect(packageJson.scripts['start:prod']).toBe('bun run dist/index.js');
+    expect(packageJson.scripts['start:prod']).toBe('bun run dist/index.asena.js');
   });
 
   it('should not include type field in package.json (CommonJS by default)', async () => {


### PR DESCRIPTION
- Added new `include` config option. This copies specified files/directories (e.g., `public/`) into the build output. Solves the issue where `@FrontendController` HTML import paths break after bundling.
- Bun build plugin marks `.html` imports as external and collects path mappings, then a post-build step rewrites the paths in bundled JS files.
- Changed default production entry point to `dist/index.asena.js`.
- Added comprehensive test suite for the build pipeline (622 lines).